### PR TITLE
Addition of api.embed.ly as an oEmbed endpoint

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -496,13 +496,14 @@ code {
 	<li> Example: <a href="http://my.opera.com/service/oembed/?url=http%3A%2F%2Fmy.opera.com%2Fcstrep%2Falbums%2Fshow.dml?id%3D504322">http://my.opera.com/service/oembed/?url=http%3A%2F%2Fmy.opera.com%2Fcstrep%2Falbums%2Fshow.dml?id%3D504322</a> </li>
 </ul>
 
-<p>Clearspring Widgets (<a href="http://widgets.clearspring.com/">http://widgets.clearspring.com/</a>)</p>
+<p> Embedly (<a href="http://api.embed.ly/">http://api.embed.ly</a>)</p>
 
 <ul>
-	<li> API endpoint: <code>http://widgets.clearspring.com/widget/v1/oembed/</code> </li>
-	<li> Example: <a href="http://widgets.clearspring.com/widget/v1/oembed/?url=http://www.clearspring.com/widgets/480fbb38b51cb736">http://widgets.clearspring.com/widget/v1/oembed/?url=http://www.clearspring.com/widgets/480fbb38b51cb736</a> </li>
+    <li> URL scheme: Various (see docs) </li>
+    <li> API endpoint: <code>http://api.embed.ly/1/oembed</code> </li>
+    <li> Documentation: <a href="http://api.embed.ly/documentation">http://api.embed.ly/documentation</a>
+    <li> Example: <a href="http://api.embed.ly/1/oembed?url=http://www.youtube.com/watch%3Fv%3DB-m6JDYRFvk">http://api.embed.ly/1/oembed?url=http://www.youtube.com/watch%3Fv%3DB-m6JDYRFvk</a></li>
 </ul>
-
 
 <a name="section7.2" id="section7.2"><h3>7.2. Consumers</h3></a>
 


### PR DESCRIPTION
Added api.embed.ly as an oEmbed endpoint and removed clearspring widgets as it's a dead oEmbed api. 

Thanks,

Sean
