### PR TITLE
Update the URLs of the Vimeo endpoint and example

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -474,10 +474,10 @@ code {
 <p>Vimeo (<a href="http://vimeo.com/">http://vimeo.com/</a>)</p>
 <ul>
 	<li> Docs: <a href="http://vimeo.com/api/docs/oembed">http://vimeo.com/api/docs/oembed</a> </li>
-	<li> URL scheme (video): <code>http://www.vimeo.com/*</code> </li>
-	<li> URL scheme (group video): <code>http://www.vimeo.com/groups/*/*</code> </li>
-	<li> Endpoint: <code>http://www.vimeo.com/api/oembed.{format}</code> </li>
-	<li> Example: <a href="http://www.vimeo.com/api/oembed.xml?url=http%3A//www.vimeo.com/757219">http://www.vimeo.com/api/oembed.xml?url=http%3A//www.vimeo.com/757219</a> </li>
+	<li> URL scheme (video): <code>http://vimeo.com/*</code> </li>
+	<li> URL scheme (group video): <code>http://vimeo.com/groups/*/videos/*</code> </li>
+	<li> Endpoint: <code>http://vimeo.com/api/oembed.{format}</code> </li>
+	<li> Example: <a href="http://vimeo.com/api/oembed.xml?url=http%3A//vimeo.com/7100569">http://vimeo.com/api/oembed.xml?url=http%3A//vimeo.com/7100569</a> </li>
 </ul>
 
 <p>oohEmbed (<a href="http://oohembed.com/">http://oohembed.com/</a>)</p>


### PR DESCRIPTION
We recently removed the www and the video that was on there is private now, so it 404s. Fixed both of those things.
