### PR TITLE
Updated/New Flickr Oembed endpoints + misc 

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -435,9 +435,11 @@ code {
 
 <p>Flickr (<a href="http://www.flickr.com/">http://www.flickr.com/</a>)</p>
 <ul>
-	<li> URL scheme: <code>http://*.flickr.com/*</code> </li>
+	<li> URL scheme: <code>http://*.flickr.com/photos/*</code> </li>
+	<li> URL scheme: <code>http://flic.kr/p/*</code> </li>
 	<li> API endpoint: <code>http://www.flickr.com/services/oembed/</code> </li>
-	<li> Example: <a href="http://flickr.com/services/oembed?url=http%3A//flickr.com/photos/bees/2362225867/">http://flickr.com/services/oembed?url=http%3A//flickr.com/photos/bees/2362225867/</a></li>
+	<li> Example: <a href="http://flickr.com/services/oembed?url=http%3A//flickr.com/photos/bees/2362225867/">http://flickr.com/services/oembed?url=http%3A%2F%2Fflickr.com%2Fphotos%2Fbees%2F2362225867%2F</a></li>
+	<li> Supports discovery via <code>&lt;link&gt;</code> tags </li>
 </ul>
 
 <p>Viddler (<a href="http://www.viddler.com/">http://www.viddler.com/</a>)</p>


### PR DESCRIPTION
-I've updated Flickr's oembed API endpoints (There was an endpoint missing the other one was incorrect)

-Flickr now supports discovery via <link> tags

-Discovery markup sample has the parameter "URL" incorrectly encoded
