### PR TITLE
Make oohEmbed a sub-element of Embedly

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -506,13 +506,6 @@ code {
 	<li> Supports discovery via <code>&lt;link&gt;</code> tags </li>
 </ul>
 
-<p>oohEmbed (<a href="http://oohembed.com/">http://oohembed.com/</a>)</p>
-<ul>
-	<li> URL scheme: Various (see docs) </li>
-	<li> Endpoint: <code>http://oohembed.com/oohembed/</code> </li>
-	<li> Example: <a href="http://oohembed.com/oohembed/?url=http%3A//www.amazon.com/Myths-Innovation-Scott-Berkun/dp/0596527055/">http://oohembed.com/oohembed/?url=http%3A//www.amazon.com/Myths-Innovation-Scott-Berkun/dp/0596527055/</a> </li>
-</ul>
-
 <p>Poll Everywhere (<a href="http://www.polleverywhere.com/">http://www.polleverywhere.com/</a>)</p>
 
 <ul>
@@ -539,6 +532,7 @@ code {
     <li> API endpoint: <code>http://api.embed.ly/1/oembed</code> </li>
     <li> Documentation: <a href="http://api.embed.ly/documentation">http://api.embed.ly/documentation</a>
     <li> Example: <a href="http://api.embed.ly/1/oembed?url=http://www.youtube.com/watch%3Fv%3DB-m6JDYRFvk">http://api.embed.ly/1/oembed?url=http://www.youtube.com/watch%3Fv%3DB-m6JDYRFvk</a></li>
+    <li> Incorporating oohEmbed (<a href="http://oohembed.com/">http://oohembed.com/</a>)</li>
 </ul>
 
 <p> iFixit (<a href="http://www.iFixit.com">http://www.iFixit.com</a>)</p>


### PR DESCRIPTION
Since oohEmbed's page says it was taken over by Embedly in 2011, seems sensible to include the information relating to it under Embedly's listing
