### PR TITLE
Added IFTTT to the Providers list

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -426,6 +426,14 @@ code {
 
 <a name="section7.1" id="section7.1"><h3>7.1. Providers</h3></a>
 
+<p>IFTTT (<a href="http://www.ifttt.com/">http://www.ifttt.com/</a>)</p>
+<ul>
+	<li> URL scheme: <code>http://ifttt.com/recipes/*</code> </li>
+	<li> API endpoint: <code>http://www.ifttt.com/oembed/</code> </li>
+	<li> Example: <a href="https://ifttt.com/oembed?url=https%3A%2F%2Fifttt.com%2Frecipes%2F107745">https://ifttt.com/oembed?url=https%3A%2F%2Fifttt.com%2Frecipes%2F107745</a></li>
+	<li> Supports discovery via <code>&lt;link&gt;</code> tags </li>
+</ul>
+
 <p>YouTube (<a href="http://www.youtube.com/">http://www.youtube.com/</a>)</p>
 <ul>
 	<li> API endpoint: <code>http://www.youtube.com/oembed</code> </li>


### PR DESCRIPTION
IFTTT is a service that lets you create powerful connections with one simple statement: if this then that. (Learn more at www.ifttt.com/wtf).

IFTTT supports embedding it's recipes through an oembed API, and I have added it to the list of providers, following the format of the other websites in the list.

Finally, made a few spelling changes 'paramater' -> 'parameter'.
