### PR TITLE
fix yahoo developer network link

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -722,7 +722,7 @@ code {
 	<li><a href="http://www.webmonkey.com/tutorial/Get_Started_With_OEmbed">Webmonkey tutorial</a></li>
 	<li><a href="http://leahculver.com/2008/05/29/announcing-oembed-an-open-standard-for-embedded-content/">Leah's blog</a></li>
 	<li><a href="http://www.readwriteweb.com/archives/oembed_open_format.php" target="_blank">ReadWriteWeb</a></li>
-	<li><a href="http://developer.yahoo.net/blog/archives/2008/05/oembed_embeddin.html">Yahoo! Developer Network</a></li>
+	<li><a href="http://developer.yahoo.com/blogs/ydn/oembed-embedding-third-party-media-made-easy-7355.html">Yahoo! Developer Network</a></li>
 	<li><a href="http://ajaxian.com/archives/oembed-makes-embedding-third-party-videos-and-images-a-breeze">ajaxian</a></li>
 	<li><a href="http://blog.hulu.com/2008/5/27/sharing-is-easy" target="_blank">Hulu blog</a></li>
 	<li><a href="http://qik.com/blog/124/qik-embraces-oembed-for-embedding-videos">Qik blog</a></li>


### PR DESCRIPTION
The YDN link was busted and redirecting to the homepage. Found the article and updated the index page.
