### PR TITLE
Added a Bunch of providers.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -604,6 +604,192 @@ code {
        <li>Supports discovery via &lt;link&gt; tags</li>
 </ul>
 
+<p>nfb.ca (<a href="http://www.nfb.ca/">http://www.nfb.ca/</a>)</p>
+<ul>
+   <li>URL Scheme: <code>http://*.nfb.ca/films/*</code> </li>
+   <li>Endpoint: <code>http://www.nfb.ca/remote/services/oembed/</code></li>
+   <li>Example: <a href="http://www.nfb.ca/remote/services/oembed/?url=http://www.nfb.ca/film/aboriginality&format=xml">http://www.nfb.ca/remote/services/oembed/?url=http://www.nfb.ca/film/aboriginality&format=xml</a></li>
+   <li>Supports discovery via &lt;link&gt; tags</li>
+</ul>
+
+<p>Scribd (<a href="http://www.scribd.com/">http://www.scribd.com/</a>)</p>
+<ul>
+	<li>URL Scheme: <code>http://www.scribd.com/doc/*</code> </li>
+	<li>Endpoint: <code>http://www.scribd.com/services/oembed/</code> </li>
+	<li>Example: <a href="http://www.scribd.com/services/oembed/?format=xml&url=http://www.scribd.com/doc/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests">http://www.scribd.com/services/oembed/?format=xml&url=http://www.scribd.com/doc/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests</a> </li>
+</ul>
+
+<p>Dotsub (<a href="http://dotsub.com/">http://dotsub.com/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://dotsub.com/view/*</code></li>
+    <li>Documentation: <a href="http://dotsub.com/solutions/oEmbed">http://dotsub.com/solutions/oEmbed</a></li>
+	<li>Endpoint: <code>http://dotsub.com/services/oembed</code></li>
+	<li>Example: <a href="http://dotsub.com/services/oembed?url=http://dotsub.com/view/665bd0d5-a9f4-4a07-9d9e-b31ba926ca78&format=xml">http://dotsub.com/services/oembed?url=http://dotsub.com/view/665bd0d5-a9f4-4a07-9d9e-b31ba926ca78&format=xml</a></li>
+</ul>
+
+<p>Animoto (<a href="http://animoto.com/">http://animoto.com/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://animoto.com/play/*</code> </li>
+	<li>API endpoint: <code>http://animoto.com/oembeds/create</code> </li>
+	<li>Documentation: <a href="http://help.animoto.com/entries/109992-oEmbed-API">http://help.animoto.com/entries/109992-oEmbed-API</a></li>
+	<li>Example: <a href="http://animoto.com/oembeds/create/?format=xml&url=http%3A%2F%2Fanimoto.com%2Fplay%2FJzwsBn5FRVxS0qoqcBP5zA">http://animoto.com/oembeds/create/?format=xml&url=http%3A%2F%2Fanimoto.com%2Fplay%2FJzwsBn5FRVxS0qoqcBP5zA</a></li>
+</ul>
+
+<p>Rdio (<a href="http://rdio.com/">http://rdio.com/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://*.rdio.com/artist/*</code> </li>
+	<li>URL scheme: <code>http://*.rdio.com/people/*</code> </li>
+	<li>API endpoint: <code>http://www.rdio.com/api/oembed/</code> </li>
+	<li>Documentation: <a href="http://developer.rdio.com/docs/oEmbed">http://developer.rdio.com/docs/oEmbed</a></li>
+	<li>Example: <a href="http://www.rdio.com/api/oembed/?format=json&url=http://www.rdio.com/artist/The_Black_Keys/album/Brothers/">http://www.rdio.com/api/oembed/?format=json&url=http://www.rdio.com/artist/The_Black_Keys/album/Brothers/</a></li>
+</ul>
+
+<p>MixCloud (<a href="http://mixcloud.com/">http://mixcloud.com</a>)</p>
+<ul>
+	<li>URL Scheme: <code>http://www.mixcloud.com/*/*/</code> </li>
+	<li>Endpoint: <code>http://www.mixcloud.com/oembed/</code> </li>
+	<li>Documentation: <a href="http://www.mixcloud.com/developers/documentation/">http://www.mixcloud.com/developers/documentation/</a></li>
+	<li>Example: <a href="http://www.mixcloud.com/oembed/?url=http%3A//www.mixcloud.com/TechnoLiveSets/jon_rundell-live-electrobeach-festival-benidorm-16-08-2013/&format=xml">http://www.mixcloud.com/oembed/?url=http%3A//www.mixcloud.com/TechnoLiveSets/jon_rundell-live-electrobeach-festival-benidorm-16-08-2013/&format=xml</a> </li>
+</ul>
+
+<p>Screenr (<a href="http://www.screenr.com/">http://www.screenr.com</a>)</p>
+<ul>
+	<li>URL Scheme: <code>http://www.screenr.com/*/</code> </li>
+    <li>Endpoint: <code>http://www.screenr.com/api/oembed.{format}</code> </li>
+	<li>Example: <a href="http://www.screenr.com/api/oembed.xml?url=http://screenr.com/3jns">http://www.screenr.com/api/oembed.xml?url=http://screenr.com/3jns</a> </li>
+</ul>
+
+<p>FunnyOrDie (<a href="http://www.funnyordie.com/">http://www.funnyordie.com/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.funnyordie.com/videos/*</code> </li>
+    <li>API endpoint: <code>http://www.funnyordie.com/oembed.{format}</code> </li>
+	<li>Example: <a href="http://www.funnyordie.com/oembed.xml?url=http://www.funnyordie.com/videos/a7311134ac/patton-oswalt-in-heavy-metal">http://www.funnyordie.com/oembed.xml?url=http://www.funnyordie.com/videos/a7311134ac/patton-oswalt-in-heavy-metal</a></li>
+</ul>
+
+<p>Poll Daddy (<a href="http://polldaddy.com">http://polldaddy.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://*.polldaddy.com/s/*</code> </li>
+	<li>URL scheme: <code>http://*.polldaddy.com/poll/*</code> </li>
+	<li>URL scheme: <code>http://*.polldaddy.com/ratings/*</code> </li>
+    <li>API endpoint: <code>http://polldaddy.com/oembed/</code> </li>
+	<li>Documentation: <a href="http://support.polldaddy.com/oembed/">http://support.polldaddy.com/oembed/</a></li>
+	<li>Example: <a href="http://polldaddy.com/oembed/?url=http://polldaddy.com/ratings/39/&format=xml">http://polldaddy.com/oembed/?url=http://polldaddy.com/ratings/39/&format=xml</a></li>
+</ul>
+
+<p>Ted (<a href="http://ted.com">http://ted.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://ted.com/talks/*</code> </li>
+	<li>Example: <a href="http://www.ted.com/talks/oembed.xml?url=http://www.ted.com/talks/jill_bolte_taylor_s_powerful_stroke_of_insight.html">http://www.ted.com/talks/oembed.xml?url=http://www.ted.com/talks/jill_bolte_taylor_s_powerful_stroke_of_insight.html</a></li>
+</ul>
+
+<p>VideoJug (<a href="http://www.videojug.com">http://videos.sapo.pt/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.videojug.com/film/*</code> </li>
+	<li>URL scheme: <code>http://www.videojug.com/interview/*</code> </li>
+    <li>API endpoint: <code>http://www.videojug.com/oembed.{format}</code> </li>
+	<li>Example: <a href="http://www.videojug.com/oembed.xml?url=http://www.videojug.com/film/how-to-tie-a-knot-braid">http://www.videojug.com/oembed.xml?url=http://www.videojug.com/film/how-to-tie-a-knot-braid</a></li>
+</ul>
+
+<p>Sapo Videos (<a href="http://videos.sapo.pt">http://videos.sapo.pt</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://videos.sapo.pt/*</code> </li>
+    <li>API endpoint: <code>http://videos.sapo.pt/oembed</code> </li>
+	<li>Example: <a href="http://videos.sapo.pt/oembed?url=http://videos.sapo.pt/dNbiosGa9YZHfLrhkA88&format=xml">http://videos.sapo.pt/oembed?url=http://videos.sapo.pt/dNbiosGa9YZHfLrhkA88&format=xml</a></li>
+</ul>
+
+<p>Justin.tv (<a href="http://www.justin.tv">http://www.justin.tv</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.justin.tv/*</code> </li>
+    <li>API endpoint: <code>http://api.justin.tv/api/embed/from_url.{json}</code> </li>
+	<li>Example: <a href="http://api.justin.tv/api/embed/from_url.xml?url=http://www.justin.tv/deepellumonair">http://api.justin.tv/api/embed/from_url.xml?url=http://www.justin.tv/deepellumonair</a></li>
+</ul>
+
+<p>Official FM (<a href="http://official.fm">http://official.fm/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://official.fm/tracks/*</code> </li>
+	<li>URL scheme: <code>http://official.fm/playlists/*</code> </li>
+    <li>API endpoint: <code>http://official.fm/services/oembed.{format}</code> </li>
+	<li>Documentation: <a href="https://github.com/officialfm/api/blob/master/sections/oembed.md">https://github.com/officialfm/api/blob/master/sections/oembed.md</a></li>
+	<li>Example: <a href="http://official.fm/services/oembed.json?url=http://official.fm/tracks/npTR">http://official.fm/services/oembed.json?url=http://official.fm/tracks/npTR</a></li>
+</ul>
+
+<p>HuffDuffer (<a href="http://huffduffer.com">http://huffduffer.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://huffduffer.com/*/*</code> </li>
+    <li>API endpoint: <code>http://huffduffer.com/oembed</code> </li>
+	<li>Example: <a href="http://huffduffer.com/oembed?url=http://huffduffer.com/jxpx777/125342&format=xml">http://huffduffer.com/oembed?url=http://huffduffer.com/jxpx777/125342&format=xml</a></li>
+</ul>
+
+<p>Shoudio (<a href="http://shoudio.com">http://shoudio.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://shoudio.com/*</code> </li>
+	<li>URL scheme: <code>http://shoud.io/*</code> </li>
+    <li>API endpoint: <code>http://shoudio.com/api/oembed</code> </li>
+	<li>Example: <a href="http://shoudio.com/api/oembed?format=xml&url=http://shoudio.com/user/shoister/status/8122">http://shoudio.com/api/oembed?format=xml&url=http://shoudio.com/user/shoister/status/8122</a></li>
+</ul>
+
+<p>Moby Picture (<a href="http://www.mobypicture.com">http://www.mobypicture.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.mobypicture.com/user/*/view/*</code> </li>
+	<li>URL scheme: <code>http://moby.to/*</code> </li>
+    <li>API endpoint: <code>http://api.mobypicture.com/oEmbed</code> </li>
+	<li>Example: <a href="http://api.mobypicture.com/oEmbed?format=xml&url=http://mobypicture.com/user/Henk_Voermans/view/15880044">http://api.mobypicture.com/oEmbed?format=xml&url=http://mobypicture.com/user/Henk_Voermans/view/15880044</a></li>
+</ul>
+
+<p>23HQ (<a href="http://www.23hq.com">http://www.23hq.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.23hq.com/*/photo/*</code> </li>
+    <li>API endpoint: <code>http://www.23hq.com/23/oembed</code> </li>
+	<li>Example: <a href="http://www.23hq.com/23/oembed?url=http://www.23hq.com/mprove/photo/13297717">http://www.23hq.com/23/oembed?url=http://www.23hq.com/mprove/photo/13297717</a></li>
+</ul>
+
+<p>Urtak (<a href="http://urtak.com">http://urtak.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://urtak.com/u/*</code> </li>
+	<li>URL scheme: <code>http://urtak.com/clr/*</code> </li>
+    <li>API endpoint: <code>http://oembed.urtak.com/1/oembed</code> </li>
+	<li>Documentation: <a href="http://oembed.urtak.com/">http://oembed.urtak.com/</a></li>
+	<li>Example: <a href="http://oembed.urtak.com/1/oembed?format=xml&url=https://www.urtak.com/u/9387/">http://oembed.urtak.com/1/oembed?format=xml&url=https://www.urtak.com/u/9387/</a></li>
+</ul>
+
+<p>Cacoo (<a href="https://cacoo.com">https://cacoo.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>https://cacoo.com/diagrams/*</code> </li>
+    <li>API endpoint: <code>http://cacoo.com/oembed.{format}</code> </li>
+	<li>Documentation: <a href="https://cacoo.com/lang/en/api_oembed">https://cacoo.com/lang/en/api_oembed</a></li>
+	<li>Example: <a href="http://cacoo.com/oembed.xml?url=http://cacoo.com/diagrams/m9uZtizE5I2GkFR6">http://cacoo.com/oembed.xml?url=http://cacoo.com/diagrams/m9uZtizE5I2GkFR6/</a></li>
+</ul>
+
+<p>Dipity (<a href="http://www.dipity.com">http://www.dipity.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.dipity.com/*/*/</code> </li>
+    <li>API endpoint: <code>http://www.dipity.com/oembed/timeline/</code> </li>
+	<li>Example: <a href="http://www.dipity.com/oembed/timeline/?format=xml&url=http://www.dipity.com/ragutier/Historia_de_la_Web/">http://www.dipity.com/oembed/timeline/?format=xml&url=http://www.dipity.com/ragutier/Historia_de_la_Web/</a></li>
+</ul>
+
+<p>Roomshare (<a href="http://roomshare.jp">http://roomshare.jp</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://roomshare.jp/post/*</code> </li>
+	<li>URL scheme: <code>http://roomshare.jp/en/post/*</code> </li>
+    <li>API endpoint: <code>http://roomshare.jp/en/oembed.{format}</code> </li>
+	<li>Example: <a href="http://roomshare.jp/en/oembed.xml?url=http://roomshare.jp/en/post/137167">http://roomshare.jp/en/oembed.xml?url=http://roomshare.jp/en/post/137167</a></li>
+</ul>
+
+<p>Daily Motion (<a href="http://www.dailymotion.com">http://www.dailymotion.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://www.dailymotion.com/video/*</code> </li>
+    <li>API endpoint: <code>http://www.dailymotion.com/services/oembed</code> </li>
+	<li>Documentation: <a href="http://www.dailymotion.com/doc/api/oembed.html">http://www.dailymotion.com/doc/api/oembed.html</a></li>
+	<li>Example: <a href="http://www.dailymotion.com/services/oembed?format=xml&url=http://www.dailymotion.com/video/xoxulz_babysitter_animals">http://www.dailymotion.com/services/oembed?format=xml&url=http://www.dailymotion.com/video/xoxulz_babysitter_animals</a></li>
+</ul>
+
+<p>Crowd Ranking (<a href="http://crowdranking.com">http://crowdranking.com</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://crowdranking.com/*/*</code> </li>
+    <li>API endpoint: <code>http://crowdranking.com/api/oembed.{format}</code> </li>
+	<li>Example: <a href="http://crowdranking.com/api/oembed.xml?url=http://crowdranking.com/rankings/t470g0--best-tea">http://crowdranking.com/api/oembed.xml?url=http://crowdranking.com/rankings/t470g0--best-tea</a></li>
+</ul>
+
 <p>CircuitLab (<a href="https://www.circuitlab.com/">https://www.circuitlab.com/</a>)</p>
 <ul>
 	<li> URL scheme: <code>https://www.circuitlab.com/circuit/*</code> </li>


### PR DESCRIPTION
Hi Cal!

I rewrote my previous pull request. I decided to split the valid and invalid providers into different branches.
So Here is a list with providers that closely follow the oembed spec

The list of providers added is:
- Added nfb.ca
- Added scribd.com
- Added dotsub.com
- Added Animoto.com
- Added Rdio.com
- Added Mixcloud.com
- Added Screenr.com
- Added FunnyOrDie.com
- Added Polldaddy.com
- Added Ted.com
- Added Videojug.com
- Added Sapo.pt
- Added Justin.tv
- Added Official.fm
- Added Huffduffer.com
- Added Shoudio.com
- Added MobyPicture.com
- Added 23hq.com
- Added Urtak.com
- Added Cacoo.com
- Added Dipity.com
- Added Roomshare.jp
- Added DailyMotion.com
- Added CrowdRanking.com
