### PR TITLE
Add PyEmbed to libraries section.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -992,6 +992,7 @@ code {
 	<li>PHP: Embera (<a href="https://github.com/mpratt/Embera">https://github.com/mpratt/Embera</a>)</li>
 	<li>Perl: Web-oEmbed (<a href="http://search.cpan.org/~miyagawa/Web-oEmbed/">http://search.cpan.org/~miyagawa/Web-oEmbed/</a>)</li>
 	<li>Ruby: oembed_links (<a href="http://github.com/netshade/oembed_links">http://github.com/netshade/oembed_links</a>)</li>
+	<li>Python: PyEmbed (<a href="http://pyembed.github.io">http://pyembed.github.io</a>)</li>
 	<li>Python oEmbed (<a href="http://code.google.com/p/python-oembed/">http://code.google.com/p/python-oembed/</a>)</li>
 	<li>Django: djangoembed (<a href="http://github.com/worldcompany/djangoembed">http://github.com/worldcompany/djangoembed</a>)</li>
 	<li>Java: java-oembed (<a href="https://github.com/michael-simons/java-oembed">https://github.com/michael-simons/java-oembed</a>)</li>


### PR DESCRIPTION
I've just released PyEmbed, an oEmbed consumer library for Python.  It comes with support for documents written in Markdown and reStructuredText, customizable embeddings, and automatic discovery of producers.

This commit adds a link to PyEmbed from the oEmbed docs.
