### PR TITLE
Added audiosnaps.com as provider

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -958,6 +958,15 @@ code {
 	<li>Example: <a href="https://api.meetup.com/oembed?format=json&url=http://www.meetup.com/PHPColMeetup/photos/">https://api.meetup.com/oembed?format=json&url=http://www.meetup.com/PHPColMeetup/photos/</a></li>
 </ul>
 
+<p>AudioSnaps (<a href="http://audiosnaps.com">http://audiosnaps.com/</a>)</p>
+<ul>
+	<li>URL scheme: <code>http://audiosnaps.com/k/*</code> </li>
+	<li>API Endpoint: <code>http://audiosnaps.com/service/oembed</code> </li>
+	<li>Example: <a href="http://audiosnaps.com/service/oembed?url=http://audiosnaps.com/k/d8wi/&format=json">http://audiosnaps.com/service/oembed?url=http://audiosnaps.com/k/d8wi/&format=json</a> </li>
+	<li>Example: <a href="http://audiosnaps.com/service/oembed?url=http://audiosnaps.com/k/d8wi/&maxwidth=400&format=xml">http://audiosnaps.com/service/oembed?url=http://audiosnaps.com/k/d8wi/&format=xml</a> </li>
+	<li> Supports discovery via <code>&lt;link&gt;</code> tags </li>
+</ul>
+
 
 <a name="section7.2" id="section7.2"><h3>7.2. Consumers</h3></a>
 


### PR DESCRIPTION
Added audiosnaps.com as provider. Fully supports oembed:
- JSON and XML formats
- supports maxwidth and maxheight
- supports discovery via link tags
