### PR TITLE
added pyoembed

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1026,6 +1026,7 @@ code {
 	<li>PHP: Embera (<a href="https://github.com/mpratt/Embera">https://github.com/mpratt/Embera</a>)</li>
 	<li>Perl: Web-oEmbed (<a href="http://search.cpan.org/~miyagawa/Web-oEmbed/">http://search.cpan.org/~miyagawa/Web-oEmbed/</a>)</li>
 	<li>Ruby: oembed_links (<a href="http://github.com/netshade/oembed_links">http://github.com/netshade/oembed_links</a>)</li>
+	<li>Python: pyoembed (<a href="http://github.com/rafaelmartins/pyoembed/">http://github.com/rafaelmartins/pyoembed/</a>)</li>
 	<li>Python: PyEmbed (<a href="http://pyembed.github.io">http://pyembed.github.io</a>)</li>
 	<li>Python oEmbed (<a href="http://code.google.com/p/python-oembed/">http://code.google.com/p/python-oembed/</a>)</li>
 	<li>Django: djangoembed (<a href="http://github.com/worldcompany/djangoembed">http://github.com/worldcompany/djangoembed</a>)</li>


### PR DESCRIPTION
pyoembed is a python implementation of the oembed protocol that supports
both explicitly-defined and autodiscovered providers.
