### PR TITLE
Removed Justin.tv from the providers list.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -685,13 +685,6 @@ code {
 	<li>Example: <a href="http://videos.sapo.pt/oembed?url=http://videos.sapo.pt/dNbiosGa9YZHfLrhkA88&format=xml">http://videos.sapo.pt/oembed?url=http://videos.sapo.pt/dNbiosGa9YZHfLrhkA88&format=xml</a></li>
 </ul>
 
-<p>Justin.tv (<a href="http://www.justin.tv">http://www.justin.tv</a>)</p>
-<ul>
-	<li>URL scheme: <code>http://www.justin.tv/*</code> </li>
-    <li>API endpoint: <code>http://api.justin.tv/api/embed/from_url.{format}</code> </li>
-	<li>Example: <a href="http://api.justin.tv/api/embed/from_url.xml?url=http://www.justin.tv/deepellumonair">http://api.justin.tv/api/embed/from_url.xml?url=http://www.justin.tv/deepellumonair</a></li>
-</ul>
-
 <p>Official FM (<a href="http://official.fm">http://official.fm/</a>)</p>
 <ul>
 	<li>URL scheme: <code>http://official.fm/tracks/*</code> </li>


### PR DESCRIPTION
Hi Cal,

The Justin.tv website, mobile apps, and APIs are no longer in service. 

I believe they turned into http://www.twitch.tv/ but sadly I havent found an oembed endpoint for that website :sob: 
