### PR TITLE
Fixing link to GettyImages oembed documentation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -981,7 +981,7 @@ code {
 <ul>
 	<li> URL scheme: <code>http://gty.im/*</code> </li>
 	<li> API endpoint: <code>http://embed.gettyimages.com/oembed (only supports json)</code> </li>
-	<li> Documentation: <a href="https://github.com/gettyimages/connect/blob/master/v2/endpoints/oembed/oEmbed.md">http://github.com/gettyimages/connect/blob/master/documentation/endpoints/oembed/oEmbed.md</a> </li>
+	<li> Documentation: <a href="http://github.com/gettyimages/connect/blob/master/v2/endpoints/oembed/oEmbed.md">http://github.com/gettyimages/connect/blob/master/documentation/endpoints/oembed/oEmbed.md</a> </li>
 	<li> Example: <a href="http://embed.gettyimages.com/oembed?url=http%3a%2f%2fgty.im%2f74917285">http://embed.gettyimages.com/oembed?url=http%3a%2f%2fgty.im%2f74917285</a></li>
 </ul>
 


### PR DESCRIPTION
Fixing link to GettyImages oembed documentation
