### PR TITLE
Added link to oembedapi.com - open API for open-source projects

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1041,6 +1041,7 @@ code {
 	<li>.Net: oEmbed API Wrapper (<a href="http://oembed.codeplex.com/">http://oembed.codeplex.com/</a>)</li>
 	<li>JQuery: oEmbed API Wrapper (<a href="https://github.com/starfishmod/jquery-oembed-all">https://github.com/starfishmod/jquery-oembed-all</a>)</li>
 	<li>Node.js: oEmbed API Gateway (<a href="https://github.com/itteco/iframely">https://github.com/itteco/iframely</a>)</li>	
+	<li>Any: oEmbed API proxy endpoint for open-source projects (<a href="http://oembedapi.com">http://oembedapi.com</a>)</li>
 </ul>
 
 


### PR DESCRIPTION
Not sure if that's the best section to add to. As I see it, it does qualify as the library, even though it is a hosted API endpoint.

Here's the idea: number of open-source projects asked us about open API endpoint so that they can a) support oEmbed and b) include default proxy endpoint into their packages and c) allow their users to re-configure to any of oEmbed implementations they want when they start using packages.

oembedapi.com lists such a proxy API endpoint for any of the open-source projects. We believe it should make it easier for open-source developers to rely on oEmbed and will help the community. 

Also, the same endpoint can be used to convert from Twitter Cards and Open Graph into oEmbed format, so that publishers can easily join oEmbed community.

This said, such an open service should help oEmbed distribution in both directions. What do you think?