### PR TITLE
revision3 oembed endpoint is gone.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -459,13 +459,6 @@ code {
 	<li> Example: <a href="http://www.viddler.com/oembed/?format=xml&amp;url=http%3A%2F%2Fwww.viddler.com%2Fv%2F1646c55">http://www.viddler.com/oembed/?format=xml&amp;url=http%3A%2F%2Fwww.viddler.com%2Fv%2F1646c55</a> </li>
 </ul>
 
-<p>Revision3 (<a href="http://revision3.com/">http://revision3.com/</a>)</p>
-<ul>
-	<li> URL scheme: <code>http://*.revision3.com/*</code> </li>
-	<li> API endpoint: <code>http://revision3.com/api/oembed/</code> </li>
-	<li> Example: <a href="http://revision3.com/api/oembed/?url=http%3A//revision3.com/diggnation/2008-04-17xsanned/&format=xml">http://revision3.com/api/oembed/?url=http%3A//revision3.com/diggnation/2008-04-17xsanned/&format=xml</a> </li>
-</ul>
-
 <p>Hulu (<a href="http://www.hulu.com/">http://www.hulu.com/</a>)</p>
 <ul>
 	<li> URL scheme: <code>http://www.hulu.com/watch/*</code> </li>


### PR DESCRIPTION
response on 4 july 2015 to example request:

```xml
<?xml version="1.0" encoding="utf-8"?>
<data><error>Invalid API function specified. Oembed</error></data>
```