### PR TITLE
ifixit URL scheme should also match the provided working example.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -541,6 +541,7 @@ code {
 
 <ul>
 	<li> URL scheme: <code>http://www.ifixit.com/Guide/View/*</code> </li>
+	<li> URL scheme: <code>http://www.ifixit.com/Teardown/*</code> </li>
 	<li> Endpoint: <code>http://www.ifixit.com/Embed</code> </li>
 	<li> Documentation: <a href="http://www.ifixit.com/api/doc/embed">http://www.ifixit.com/api/doc/embed</a> </li>
 	<li> Example: <a href="http://www.ifixit.com/Embed?url=http%3A%2F%2Fwww.ifixit.com%2FTeardown%2FiPhone-4-Teardown%2F3130%2F1&format=json">http://www.ifixit.com/Embed?url=http%3A%2F%2Fwww.ifixit.com%2FTeardown%2FiPhone-4-Teardown%2F3130%2F1&format=json</a> </li>


### PR DESCRIPTION
The schemes for a provider definition should match the example if the example call is valid. Is this a reasonable expectation?