### PR TITLE
use public youtube video in provider example.

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -438,7 +438,7 @@ code {
 <ul>
 	<li> API endpoint: <code>http://www.youtube.com/oembed</code> </li>
 	<li> Supports discovery via <code>&lt;link&gt;</code> tags </li>
-	<li> Example: <a href="http://www.youtube.com/oembed?url=http%3A//www.youtube.com/watch?v%3D-UUx10KOWIE&format=xml">http://www.youtube.com/oembed?url=http%3A//www.youtube.com/watch?v%3D-UUx10KOWIE&format=xml</a></li>
+	<li> Example: <a href="http://www.youtube.com/oembed?url=http%3A//www.youtube.com/watch?v%3DC0DPdy98e4c&format=xml">http://www.youtube.com/oembed?url=http%3A//www.youtube.com/watch?v%3DC0DPdy98e4c&format=xml</a></li>
 </ul>
 
 <p>Flickr (<a href="http://www.flickr.com/">http://www.flickr.com/</a>)</p>


### PR DESCRIPTION
The video in the example http://www.youtube.com/watch?v=-UUx10KOWIE is private. This pull request replaces the URL in the example with an old generic public video. https://www.youtube.com/watch?v=C0DPdy98e4c