### PR TITLE
endpoints - url added for ted.com

### DIFF
--- a/providers.yml
+++ b/providers.yml
@@ -274,6 +274,7 @@
   endpoints:
     - schemes:
         - 'http://ted.com/talks/*'
+      url: 'http://www.ted.com/talks/oembed.{format}'
       example_urls:
         - 'http://www.ted.com/talks/oembed.xml?url=http%3A%2F%2Fwww.ted.com%2Ftalks%2Fjill_bolte_taylor_s_powerful_stroke_of_insight.html'
 


### PR DESCRIPTION
The endpoints url was missing for ted.com.