### PR TITLE
Add HTTPS versions for schemes of Vimeo provider

### DIFF
--- a/providers.yml
+++ b/providers.yml
@@ -54,6 +54,8 @@
       schemes:
         - 'http://vimeo.com/*'
         - 'http://vimeo.com/groups/*/videos/*'
+        - 'https://vimeo.com/*'
+        - 'https://vimeo.com/groups/*/videos/*'
       url: 'http://vimeo.com/api/oembed.{format}'
       example_urls:
         - 'http://vimeo.com/api/oembed.xml?url=http%3A%2F%2Fvimeo.com%2F7100569'


### PR DESCRIPTION
They seem to work. See https://vimeo.com/api/oembed.json?url=https%3A%2F%2Fvimeo.com%2F115154289