### PR TITLE
Add HTTPS versions for schemes of Instagram provider

### DIFF
--- a/providers.yml
+++ b/providers.yml
@@ -510,11 +510,13 @@
         - json
 
 - provider_name: Instagram
-  provider_url: 'http://instagram.com'
+  provider_url: 'https://instagram.com'
   endpoints:
     - schemes:
         - 'http://instagram.com/p/*'
         - 'http://instagr.am/p/*'
+        - 'https://instagram.com/p/*'
+        - 'https://instagr.am/p/*'
       url: 'http://api.instagram.com/oembed'
       docs_url: 'http://instagram.com/developer/embedding/#oembed'
       example_urls:


### PR DESCRIPTION
This seems to work. See https://api.instagram.com/publicapi/oembed/?url=https://instagram.com/p/52yI4XPM3i/