### PR TITLE
Add provider for EgliseInfo

### DIFF
--- a/providers.yml
+++ b/providers.yml
@@ -785,4 +785,13 @@
       example_urls:
         - 'https://www.oumy.com/oembed?url=https%3A%2F%2Fwww.oumy.com%2Fv%2F0NmY0agdvcA7wlvIXbJaBzA&format=json'
       discovery: true
-
+- provider_name: EgliseInfo
+  provider_url: 'http://egliseinfo.catholique.fr/'
+  endpoints:
+    - schemes:
+        - 'http://egliseinfo.catholique.fr/*'
+      url: 'http://egliseinfo.catholique.fr/api/oembed'
+      example_urls:
+        - 'http://egliseinfo.catholique.fr/api/oembed?url=http%3A%2F%2Fegliseinfo.catholique.fr%2Fhoraires%2Fparis&format=json'
+        - 'http://egliseinfo.catholique.fr/api/oembed?url=http%3A%2F%2Fegliseinfo.catholique.fr%2Fhoraires%2Fparis&format=xml'
+      discovery: true


### PR DESCRIPTION
EglsieInfo is a French website for catholic to know the hour of church celebration. It's allow to a webmaster to embed a search result in a widget.