### PR TITLE
add provider Codepoints

### DIFF
--- a/providers.yml
+++ b/providers.yml
@@ -846,3 +846,18 @@
         - 'http://world.silk.co/explore/map/collection/country/numeric/total%20life%20expectancy/location/title/on/silk.co/pin/filter/matches/region/Africa'
         - 'https://women-in-film.silk.co/s/embed/stackchart/collection/bechdel-test-results-through-time/numeric/less-than-two-named-women-in-it/numeric/two-or-more-women-but-who-dont-talk-to-each-other/numeric/the-two-or-more-women-who-talk-to-each-other-but-only-discuss-men/numeric/passed'
       discovery: true
+
+- provider_name: Codepoints
+  provider_url: 'https://codepoints.net'
+  endpoints:
+    - schemes:
+        - 'http://codepoints.net/*'
+        - 'https://codepoints.net/*'
+        - 'http://www.codepoints.net/*'
+        - 'https://www.codepoints.net/*'
+      url: 'https://codepoints.net/api/v1/oembed'
+      example_urls:
+        - 'https://codepoints.net/api/v1/oembed?url=https%3A%2F%2Fcodepoints.net%2FU%2B00E4&format=json'
+        - 'https://codepoints.net/api/v1/oembed?url=https%3A%2F%2Fcodepoints.net%2FA&format=xml&maxwidth=64'
+        - 'https://codepoints.net/U+2665'
+      discovery: true


### PR DESCRIPTION
Codepoints.net is, as of now, an oEmbed provider with `<link>` elements for discovery. Please consider adding it to providers.yml!