### PR TITLE
package providers as npm module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.20160119",
   "description": "oEmbed providers",
   "main": "providers.json",
+  "files": ["providers.*"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepublish": "ryaml2json -p -s providers.yml"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "oembed",
+  "version": "1.0.20160118",
+  "description": "oEmbed providers",
+  "main": "providers.json",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "ryaml2json -p -s providers.yml"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kapouer/oembed.git"
+  },
+  "keywords": [
+    "oembed",
+    "json",
+    "providers",
+    "list"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/kapouer/oembed/issues"
+  },
+  "devDependencies": {
+    "ryaml": "^0.2.6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembed-providers-unofficial",
-  "version": "1.0.20160120",
+  "version": "1.0.20160208",
   "description": "oEmbed providers",
   "main": "providers.json",
   "files": ["providers.*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembed-providers-unofficial",
-  "version": "1.0.20160119",
+  "version": "1.0.20160120",
   "description": "oEmbed providers",
   "main": "providers.json",
   "files": ["providers.*"],
@@ -18,8 +18,7 @@
     "providers",
     "list"
   ],
-  "author": "",
-  "license": "MIT",
+  "author": "Jérémy Lal <kapouer@melix.org>",
   "bugs": {
     "url": "https://github.com/kapouer/oembed/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "oembed-providers",
-  "version": "1.0.20160118",
+  "name": "oembed-providers-unofficial",
+  "version": "1.0.20160119",
   "description": "oEmbed providers",
   "main": "providers.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oembed",
+  "name": "oembed-providers",
   "version": "1.0.20160118",
   "description": "oEmbed providers",
   "main": "providers.json",

--- a/providers.yml
+++ b/providers.yml
@@ -380,6 +380,7 @@
       docs_url: 'https://developer.dailymotion.com/player#player-oembed'
       example_urls:
         - 'http://www.dailymotion.com/services/oembed?format=xml&url=http%3A%2F%2Fwww.dailymotion.com%2Fvideo%2Fxoxulz_babysitter_animals'
+      discovery: true
 
 - provider_name: 'Crowd Ranking'
   provider_url: 'http://crowdranking.com'

--- a/providers.yml
+++ b/providers.yml
@@ -59,6 +59,7 @@
       url: 'http://vimeo.com/api/oembed.{format}'
       example_urls:
         - 'http://vimeo.com/api/oembed.xml?url=http%3A%2F%2Fvimeo.com%2F7100569'
+      discovery: true
 
 - provider_name: CollegeHumor
   provider_url: 'http://www.collegehumor.com/'


### PR DESCRIPTION
Hi,

to publish as npm module, short howto:
First you need npm installed...
then you need ryaml (npm install ryaml in oembed directory).

```
npm version 1.0.20160229
npm publish
git push && git push --tags
```

I chose to give a version after the major.minor oEmbed version + a patch after the current date
in YYYYMMDD format.

You still have to set author and license in package.json, ideally,
and add a LICENSE file that match the license field in package.json.
