### PR TITLE
Update Vimeo urls

### DIFF
--- a/providers/vimeo.yml
+++ b/providers/vimeo.yml
@@ -1,15 +1,18 @@
 ---
 - provider_name: Vimeo
-  provider_url: http://vimeo.com/
+  provider_url: https://vimeo.com/
   endpoints:
-  - docs_url: http://vimeo.com/api/docs/oembed
+  - docs_url: https://developer.vimeo.com/apis/oembed
     schemes:
-    - http://vimeo.com/*
-    - http://vimeo.com/groups/*/videos/*
     - https://vimeo.com/*
+    - https://vimeo.com/album/*/video/*
+    - https://vimeo.com/channels/*/*
     - https://vimeo.com/groups/*/videos/*
-    url: http://vimeo.com/api/oembed.{format}
+    - https://vimeo.com/ondemand/*/*
+    - https://player.vimeo.com/video/*
+    url: https://vimeo.com/api/oembed.{format}
     example_urls:
-    - http://vimeo.com/api/oembed.xml?url=http%3A%2F%2Fvimeo.com%2F7100569
+    - https://vimeo.com/api/oembed.xml?url=http%3A%2F%2Fvimeo.com%2F76979871
+    - https://vimeo.com/api/oembed.json?url=http%3A%2F%2Fvimeo.com%2F76979871
     discovery: true
 ...


### PR DESCRIPTION
We're HTTPS always, so update all the urls to be HTTPS. We also moved the docs page awhile ago. Adds more schemes as well.