### PR TITLE
Fix indaco.yml

### DIFF
--- a/providers/indaco.yml
+++ b/providers/indaco.yml
@@ -4,7 +4,7 @@
   endpoints:
   - schemes:
     - https://player.indacolive.com/player/jwp/clients/*
-  - url: https://player.indacolive.com/services/oembed
+    url: https://player.indacolive.com/services/oembed
     example_urls:
     - https://player.indacolive.com/services/oembed?url=http%3A%2F%2Fplayer.indacolive.com%2fplayer%2fjwp%2fclients%2ftest%2f2016%2f9%2fpallacanestro_reggiana%2f
     formats:


### PR DESCRIPTION
A typo in the indaco.yml is causing malformed JSON to be created in the official oEmbed providers list:

```json
{
        "provider_name": "Indaco",
        "provider_url": "https:\/\/player.indacolive.com\/",
        "endpoints": [
            {
                "schemes": [
                    "https:\/\/player.indacolive.com\/player\/jwp\/clients\/*"
                ]
            },
            {
                "url": "https:\/\/player.indacolive.com\/services\/oembed",
                "formats": [
                    "json"
                ]
            }
        ]
    }
```