### PR TITLE
Twitch oembed api url broken

### DIFF
--- a/providers/twitch.yml
+++ b/providers/twitch.yml
@@ -9,7 +9,7 @@
     - https://www.twitch.tv/*
     - http://twitch.tv/*
     - https://twitch.tv/*
-    url: https//api.twitch.tv/v4/oembed
+    url: https://api.twitch.tv/v4/oembed
     docs_url: https://github.com/justintv/Twitch-API/blob/master/embed-video.md
     example_urls:
     - https://api.twitch.tv/v4/oembed?url=https%3A%2F%2Fwww.twitch.tv%2Friotgames%2Fv%2F72749628


### PR DESCRIPTION
The url should be https://api.twitch.tv, not https//api.twitch.tv.