### PR TITLE
Add provider configuration for nanoo.tv

### DIFF
--- a/providers/nanoo.yml
+++ b/providers/nanoo.yml
@@ -1,0 +1,20 @@
+---
+- provider_name: nanoo.tv
+  provider_url: https://www.nanoo.tv/
+  endpoints:
+  - schemes:
+    - http://*.nanoo.tv/link/*
+    - http://nanoo.tv/link/*
+    - http://*.nanoo.pro/link/*
+    - http://nanoo.pro/link/*
+    - https://*.nanoo.tv/link/*
+    - https://nanoo.tv/link/*
+    - https://*.nanoo.pro/link/*
+    - https://nanoo.pro/link/* 
+    url: https://www.nanoo.tv/services/oembed 
+    example_urls:
+    - http://www.nanoo.tv/services/oembed?url=https%3A%2F%2Fnanoo.tv%2Flink%2Fv%2FzBNqdjLG
+    - http://www.nanoo.tv/services/oembed?url=https%3A%2F%2Fnanoo.tv%2Flink%2Fv%2FzBNqdjLG&format=json
+    - http://www.nanoo.tv/services/oembed?url=https%3A%2F%2Fnanoo.tv%2Flink%2Fv%2FzBNqdjLG&format=xml
+    discovery: true
+...


### PR DESCRIPTION
We have recently added oembed support for video content on nanoo.tv. We have tested it with different oembed consumers and it appears to work well.

So, we would like to be added to the official oembed provider list at http://oembed.com/providers.json

If I understood the process correctly, forking your github repository, adding the new .yml file, and creating a pull request is the correct way to go; if not, please tell me what we should be doing instead.

Kind regards,

Andreas Trottmann
