### PR TITLE
Add docdroid.net

### DIFF
--- a/providers/docdroid.yml
+++ b/providers/docdroid.yml
@@ -1,0 +1,16 @@
+---
+- provider_name: DocDroid
+  provider_url: https://www.docdroid.net/
+  endpoints:
+  - schemes:
+    - https://*.docdroid.net/*
+    - http://*.docdroid.net/*
+    - https://docdro.id/*
+    - http://docdro.id/*
+    url: https://www.docdroid.net/api/oembed
+    example_urls:
+    - https://www.docdroid.net/api/oembed?url=https%3A%2F%2Fwww.docdroid.net%2FhptvUCe%2Fexample-document.docx.html
+    formats:
+    - json
+    discovery: true
+...


### PR DESCRIPTION
We have recently added oembed support for our document sharing platform [DocDroid](https://www.docdroid.net). Thus, we would like to get added to the [providers.json](http://oembed.com/providers.json) file. Thank you!