### PR TITLE
Change YouTube URLs to HTTPS

### DIFF
--- a/providers/youtube.yml
+++ b/providers/youtube.yml
@@ -1,10 +1,10 @@
 ---
 - provider_name: YouTube
-  provider_url: http://www.youtube.com/
+  provider_url: https://www.youtube.com/
   endpoints:
-  - url: http://www.youtube.com/oembed
+  - url: https://www.youtube.com/oembed
     discovery: true
     example_urls:
-    - http://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DiwGFalTRHDA
-    - http://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DiwGFalTRHDA&format=xml
+    - https://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DiwGFalTRHDA
+    - https://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DiwGFalTRHDA&format=xml
 ...


### PR DESCRIPTION
YouTube anyway redirects you to HTTPS, so we can change the endpoint URL to directly point to HTTPS