### PR TITLE
Add support for media2.giphy.com

### DIFF
--- a/providers/GIPHY.yml
+++ b/providers/GIPHY.yml
@@ -5,7 +5,7 @@
   - schemes:
     - https://giphy.com/gifs/*
     - http://gph.is/*
-    - https://media.giphy.com/media/*/giphy.gif
+    - https://media\d?.giphy.com/media/*/giphy.gif
     url: http://giphy.com/services/oembed
     example_urls:
     - http://giphy.com/services/oembed?url=https%3A%2F%2Fgiphy.com%2Fgifs%2Fcant-hardly-wait-kW8mnYSNkUYKc


### PR DESCRIPTION
GIPHY has started using multiple subdomains for image files, this modifies the regex to allow a single digit after the `media` subdomain.  I've verified that they _do not_ have any double-digit subdomains and that their OEmbed endpoint _does_ accept these