### PR TITLE
Add https scheme for SoundCloud

### DIFF
--- a/providers/soundcloud.yml
+++ b/providers/soundcloud.yml
@@ -4,6 +4,7 @@
   endpoints:
   - schemes:
     - http://soundcloud.com/*
+    - https://soundcloud.com/*
     url: https://soundcloud.com/oembed
     example_urls:
     - https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fforss%2Fflickermood


### PR DESCRIPTION
no issue
- SoundCloud is by default https so https://soundcloud/* URLs should be recognised