### PR TITLE
Support responsive rich resource types

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -311,8 +311,21 @@ code {
 	<dt><b><code>width</code></b> (required)</dt>
 	<dd>The width in pixels required to display the HTML.</dd>
 
+	<dt><b><code>min_width</code></b> (optional)</dt>
+	<dd>The minimum width in pixels required to display the HTML, if it's any lower the content will be cut off and not render properly.</dd>
+
+	<dt><b><code>max_width</code></b> (optional)</dt>
+	<dd>The maximum width in pixels to display the HTML without blank whitespace occuring.</dd>
+
 	<dt><b><code>height</code></b> (required)</dt>
 	<dd>The height in pixels required to display the HTML.</dd>
+
+	<dt><b><code>min_height</code></b> (optional)</dt>
+	<dd>The minimum height in pixels required to display the HTML, it it's any lower the content will be cut off and not render properly.</dd>
+
+	<dt><b><code>max_height</code></b> (optional)</dt>
+	<dd>The maximum height in pixels required to display the HTML without blank whitespace occuring.</dd>
+
 </dl>
 
 <p>Responses of this type must obey the <code>maxwidth</code> and <code>maxheight</code> request parameters.</p>


### PR DESCRIPTION
A lot of widgets have a minimum width or height and if the consumer
tries to scale down a rich content response for a mobile browser by
using an assumed aspect ratio from the height/width it will most likely
cut off part of the content.