### PR TITLE
Fixed Altru url

### DIFF
--- a/providers/altrulabs.yml
+++ b/providers/altrulabs.yml
@@ -4,7 +4,9 @@
   endpoints:
   - schemes:
     - https://app.altrulabs.com/*/*?answer_id=*
-    url: https://api.altrulabs.com/social/oembed (only supports json)
+    url: https://api.altrulabs.com/social/oembed
     example_urls:
     - https://api.altrulabs.com/api/v1/social/oembed?url=https%3A%2F%2Fapp.altrulabs.com%2Ftalentbrand%2Ffeed%3Fanswer_id%3D2059
+    formats:
+    - json
 ...


### PR DESCRIPTION
no issue
- `url` value for "Altru" provider was incorrectly formatted
- added `formats` attribute to specify only json is supported rather than a comment in the `url` field