### PR TITLE
Set https for dailymotion

### DIFF
--- a/providers/dailymotion.yml
+++ b/providers/dailymotion.yml
@@ -1,12 +1,12 @@
 ---
 - provider_name: Dailymotion
-  provider_url: http://www.dailymotion.com
+  provider_url: https://www.dailymotion.com
   endpoints:
   - schemes:
-    - http://www.dailymotion.com/video/*
-    url: http://www.dailymotion.com/services/oembed
+    - https://www.dailymotion.com/video/*
+    url: https://www.dailymotion.com/services/oembed
     docs_url: https://developer.dailymotion.com/player#player-oembed
     example_urls:
-    - http://www.dailymotion.com/services/oembed?format=xml&url=http%3A%2F%2Fwww.dailymotion.com%2Fvideo%2Fxoxulz_babysitter_animals
+    - https://www.dailymotion.com/services/oembed?format=xml&url=http%3A%2F%2Fwww.dailymotion.com%2Fvideo%2Fxoxulz_babysitter_animals
     discovery: true
 ...


### PR DESCRIPTION
Right now dailymotion urls are present with http in the providers.json.
Since they provide all of their urls with https this should be changed accordingly, otherwise https urls won't work but http.