### PR TITLE
Every peertube instance

### DIFF
--- a/providers/peertube.yml
+++ b/providers/peertube.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Peertube
+  provider_url: https://joinpeertube.org/en/
+  endpoints:
+  - schemes:
+    - {{peertube instance URL}}/services/oembed?url={{peertube video URL on the instance}}
+    url: {{peertube instance URL}}/services/oembed
+    docs_url: https://developer.vidyard.com/apidoc/oembed/show_v1_1.html
+    example_urls:
+    - https://framatube.org/services/oembed?url=https%3A%2F%2Fframatube.org%2Fvideos%2Fwatch%2F217eefeb-883d-45be-b7fc-a788ad8507d3
+    discovery: true
+...

--- a/providers/peertube.yml
+++ b/providers/peertube.yml
@@ -3,7 +3,7 @@
   provider_url: https://joinpeertube.org/en/
   endpoints:
   - schemes:
-    - {{peertube instance URL}}/services/oembed?url={{peertube video URL on the instance}}
+    - "{{peertube instance URL}}"/services/oembed?url="{{peertube video URL on the instance}}"
     url: {{peertube instance URL}}/services/oembed
     docs_url: https://developer.vidyard.com/apidoc/oembed/show_v1_1.html
     example_urls:


### PR DESCRIPTION
[Peertube](https://joinpeertube.org/en/) is a software that you install on a web server. It allows you to create a video hosting website, so create your "homemade YouTube".

The difference to YouTube is that it’s not intended to create a huge platform centralizing videos from the whole world on a single server farm (which is horribly expensive).

On the contrary, PeerTube’s concept is to create a [network of multiple small interconnected video hosting providers](https://instances.joinpeertube.org/instances).

See the [FAQ](https://joinpeertube.org/en/faq) for more informations.