### PR TITLE
Adding Livestream as provider

### DIFF
--- a/providers/livestream.yml
+++ b/providers/livestream.yml
@@ -1,0 +1,17 @@
+---
+- provider_name: Livestream
+  provider_url: https://livestream.com/
+  endpoints:
+  - schemes:
+    - https://livestream.com/accounts/*/events/*
+    - https://livestream.com/accounts/*/events/*/videos/*
+    - https://livestream.com/*/events/*
+    - https://livestream.com/*/events/*/videos/*
+    - https://livestream.com/*/*
+    - https://livestream.com/*/*/videos/*
+    url: https://livestream.com/oembed
+    example_urls:
+    - https://livestream.com/oembed?url=https%3A%2F%2Flivestream.com%2Flivestream%2F3camkit
+    - https://livestream.com/oembed?url=https%3A%2F%2Flivestream.com%2Flivestream%2F3camkit%2Fvideos%2F150060311
+    discovery: true
+...


### PR DESCRIPTION
### Details
Adding livestream as a oembed provider and the list of supported urls.

### Supported Urls
`https://livestream.com/accounts/{account_id}/events/{event_id}`
`https://livestream.com/accounts/{account_id}/events/{event_id}/videos/{video_id}`
`https://livestream.com/{account_name}/events/{event_id}`
`https://livestream.com/{account_name}/events/{event_id}/videos/{video_id}`
`https://livestream.com/{account_name}/{event_name}`
`https://livestream.com/{account_name}/{event_name}/videos/{video_id}`

### Endpoint
`https://livestream.com/oembed`

### Supported Query Parameters
`url` - Livestream event/video url
`autoPlay` - value can be `true|false` which sets the iframe `autoPlay` value.
`mute` - value can be `true|false` which sets the iframe `mute` value.
`width` - width of iframe, default is 640.
`height` - height of iframe, default is 360.
