### PR TITLE
Update Wistia provider name

### DIFF
--- a/providers/wistia.yml
+++ b/providers/wistia.yml
@@ -1,6 +1,6 @@
 
 ---
-- provider_name: Wistia
+- provider_name: Wistia, Inc.
   provider_url: https://wistia.com/
   endpoints:
   - docs_url: https://wistia.com/support/developers/oembed


### PR DESCRIPTION
#350 It appears this provider name is checked when used with Drupal. Updating the provider name to be in sync should fix the issue.