### PR TITLE
Added Natural Atlas provider

### DIFF
--- a/providers/naturalatlas.yml
+++ b/providers/naturalatlas.yml
@@ -1,0 +1,16 @@
+---
+- provider_name: Natural Atlas
+  provider_url: https://naturalatlas.com/
+  endpoints:
+  - schemes:
+    - https://naturalatlas.com/*
+    - https://naturalatlas.com/*/*
+    - https://naturalatlas.com/*/*/*
+    - https://naturalatlas.com/*/*/*/*
+    url: https://naturalatlas.com/oembed.{format}
+    example_urls:
+    - https://naturalatlas.com/oembed.json?url=https%3A%2F%2Fnaturalatlas.com%2Fwaterfalls%2Flower-falls-of-the-yellowstone-river-1004042
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Provides embedded maps. Example: https://naturalatlas.com/oembed.json?url=https%3A%2F%2Fnaturalatlas.com%2Fwaterfalls%2Flower-falls-of-the-yellowstone-river-1004042 → **https://naturalatlas.com/embed?widget=map&load=place:1004042&sidebar=no**