### PR TITLE
Add provider typlog

### DIFF
--- a/providers/typlog.yml
+++ b/providers/typlog.yml
@@ -1,0 +1,10 @@
+---
+- provider_name: Typlog
+  provider_url: https://typlog.com
+  endpoints:
+  - url: https://typlog.com/oembed
+    example_urls:
+    - https://typlog.com/oembed?url=https%3A//fourgifts.typlog.io/episodes/11
+    discovery: true
+    notes: Provider only supports the 'rich' type
+...


### PR DESCRIPTION
[Typlog](https://typlog.com/) is a blogging and podcast hosting platform. It supports custom domains. That's why I don't know how to add "schemes".

Should I just put `https://*.typlog.io/episodes/*` there?