### PR TITLE
Remove wrong empty line from Wista

### DIFF
--- a/providers/wistia.yml
+++ b/providers/wistia.yml
@@ -1,4 +1,3 @@
-
 ---
 - provider_name: Wistia, Inc.
   provider_url: https://wistia.com/


### PR DESCRIPTION
Causes parsing error in symphony php tools.