### PR TITLE
Updates Infogram oembed url

### DIFF
--- a/providers/infogram.yml
+++ b/providers/infogram.yml
@@ -1,10 +1,10 @@
 ---
 - provider_name: Infogram
-  provider_url: https://infogr.am/
+  provider_url: https://infogram.com/
   endpoints:
   - schemes:
-    - https://infogr.am/*
-    url: https://infogr.am/oembed
+    - https://infogram.com/*
+    url: https://infogram.com/oembed
     example_urls:
-    - https://infogr.am/oembed/?url=https%3A%2F%2Finfogr.am%2Famazon-and-the-book-market
+    - https://infogram.com/oembed/?url=https%3A%2F%2Finfogram.com%2Famazon-and-the-book-market
 ...


### PR DESCRIPTION
Hello,

The pull request commit is self explanatory, currently infogr.am redirects to infogram.com, see for instance (the specification url):

https://infogram.com/oembed/?url=https%3A%2F%2Finfogr.am%2Famazon-and-the-book-market