### PR TITLE
Add some missing instagram schemes

### DIFF
--- a/providers/instagram.yml
+++ b/providers/instagram.yml
@@ -3,6 +3,10 @@
   provider_url: https://instagram.com
   endpoints:
   - schemes:
+    - http://instagram.com/*/p/*,
+    - http://www.instagram.com/*/p/*,
+    - https://instagram.com/*/p/*,
+    - https://www.instagram.com/*/p/*, 
     - http://instagram.com/p/*
     - http://instagr.am/p/*
     - http://www.instagram.com/p/*


### PR DESCRIPTION
I added schemes variations related to URLs that contain the username as part of the shareable URL.

e.g., `https://www.instagram.com/farid_rueda/p/B6badtlCJCw/`