### PR TITLE
Fixing hearthis.at endpoint

### DIFF
--- a/providers/hearthis.yml
+++ b/providers/hearthis.yml
@@ -5,7 +5,7 @@
   - schemes:
     - https://hearthis.at/*/*/
     - https://hearthis.at/*/set/*/
-    url: https://hearthis.at/oembed/
+    url: https://hearthis.at/oembed/?format=json
     docs_url: TBD
     example_urls:
     - https://hearthis.at/oembed/?url=https://hearthis.at/gdsfm/20180922-motherland-soundsystem-im-sender/&format=json


### PR DESCRIPTION
This adds the `?format=json` GET parameter