### PR TITLE
Create padlet.yml

### DIFF
--- a/providers/padlet.yml
+++ b/providers/padlet.yml
@@ -1,0 +1,11 @@
+---
+- provider_name: Padlet
+  provider_url: https://padlet.com/
+  endpoints:
+  - schemes:
+    - https://padlet.com/*
+    url: https://padlet.com/oembed/
+    example_urls:
+    - https://padlet.com/oembed?url=https%3A//padlet.com/cogdogblog/aos9fosbbwk4&format=json
+    discovery: true
+...


### PR DESCRIPTION
Add entry for padlet.com; ombed support exists though not described anywhere in their documentation but embed is supported on WordPress.com; found while adding support for WordPress plugin