### PR TITLE
Add new Odesli/Songlink domains

### DIFF
--- a/providers/songlink.yml
+++ b/providers/songlink.yml
@@ -1,10 +1,16 @@
 
 ---
-- provider_name: Songlink
-  provider_url: https://song.link
+- provider_name: Odesli (formerly Songlink)
+  provider_url: https://odesli.co
   endpoints:
   - schemes:
     - https://song.link/*
+    - https://album.link/*
+    - https://artist.link/*
+    - https://playlist.link/*
+    - https://pods.link/*
+    - https://mylink.page/*
+    - https://odesli.co/*
     url: https://song.link/oembed
     formats:
     - json
@@ -13,4 +19,5 @@
     - https://song.link/oembed?url=https%3A%2F%2Fsong.link%2Fus%2Fi%2F1182062656&format=json
     - https://song.link/oembed?url=https%3A%2F%2Fsong.link%2Fdpmo&format=json
     - https://song.link/oembed?url=https%3A%2F%2Fsong.link%2Falbum%2Fs%2F0K4pIOOsfJ9lK8OjrZfXzd&format=json
+    - https://song.link/oembed?url=https%3A%2F%2Fartist.link%2Fmars&format=json
 ...


### PR DESCRIPTION
- This PR adds new Songlink/Odesli domains
- Songlink used to run only at https://song.link, but now it supports a handful of other pretty domains, such as album.link and artist.link. As part of these changes, Songlink rebranded to Odesli, with song.link, album.link, etc. now different domains under Odesli name.
- https://song.link/oembed will always be supported and is will tested. 