### PR TITLE
Add example Audioboom ‘canonical url’ and ‘vanity url’

### DIFF
--- a/providers/audioboom.yml
+++ b/providers/audioboom.yml
@@ -3,6 +3,7 @@
   provider_url: https://audioboom.com
   endpoints:
   - schemes:
+    - https://audioboom.com/channels/*
     - https://audioboom.com/channel/*
     - https://audioboom.com/posts/*
     url: https://audioboom.com/publishing/oembed/v4.{format}
@@ -12,6 +13,8 @@
     example_urls:
     - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
     - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
+    - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
+    - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
     - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
     - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
 ...


### PR DESCRIPTION
I had omitted a scheme, but had provided an example.