### PR TITLE
Change StoryMaps provider to single YAML document

### DIFF
--- a/providers/storymaps.yml
+++ b/providers/storymaps.yml
@@ -9,5 +9,5 @@
         - https://storymaps.arcgis.com/oembed?url=https://storymaps.arcgis.com/stories/ffdd1f0589434e8c8cf0dddbb1edd364&format=json
         - https://storymaps.arcgis.com/oembed?url=https://storymaps.arcgis.com/stories/ffdd1f0589434e8c8cf0dddbb1edd364&format=xml
       discovery: true
----
+...
 


### PR DESCRIPTION
Doesn't match template, which can break parsing, see: [`providers/README.md`](https://github.com/iamcal/oembed/blob/da3a6480003e47ff560a90792eaec1047981d2c0/providers/README.md)