### PR TITLE
Add new DocDroid domain

### DIFF
--- a/providers/docdroid.yml
+++ b/providers/docdroid.yml
@@ -7,6 +7,8 @@
     - http://*.docdroid.net/*
     - https://docdro.id/*
     - http://docdro.id/*
+    - https://*.docdroid.com/*
+    - http://*.docdroid.com/*
     url: https://www.docdroid.net/api/oembed
     example_urls:
     - https://www.docdroid.net/api/oembed?url=https%3A%2F%2Fwww.docdroid.net%2FhptvUCe%2Fexample-document.docx.html


### PR DESCRIPTION
DocDroid is now additionally using the docdroid.com domain.