### PR TITLE
Add pinpoll as provider

### DIFF
--- a/providers/pinpoll.yml
+++ b/providers/pinpoll.yml
@@ -1,0 +1,17 @@
+---
+  - provider_name: Pinpoll
+    provider_url: https://www.pinpoll.com/products/tools
+    endpoints:
+    - schemes:
+      - https://tools.pinpoll.com/*
+      url: https://tools.pinpoll.com/oembed
+      example_urls:
+      - https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/embed/1
+      - https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/answer/5
+      - https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/collection/2
+      - https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/quiz/1
+      discovery: true
+      formats:
+      - json
+      - xml
+...


### PR DESCRIPTION
Please add pinpoll as OEmbed Provider.

Example URLS:
- https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/embed/1
- https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/answer/5
- https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/collection/2
- https://tools.pinpoll.com/oembed?url=https://tools.pinpoll.com/quiz/1