### PR TITLE
Add datawrapper oEmbed provider

### DIFF
--- a/providers/datawrapper.yml
+++ b/providers/datawrapper.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Datawrapper
+  provider_url: http://www.datawrapper.de
+  endpoints:
+  - schemes:
+    - https://datawrapper.dwcdn.net/*
+    url: https://api.datawrapper.de/v3/oembed/
+    docs_url: https://developer.datawrapper.de/docs/embedding-charts-via-oembed
+    example_urls:
+    - https://api.datawrapper.de/v3/oembed/?url=https://datawrapper.dwcdn.net/RnWgL/9/
+    discovery: false
+    notes: Provider only supports the 'rich' type
+...

--- a/providers/datawrapper.yml
+++ b/providers/datawrapper.yml
@@ -5,9 +5,9 @@
   - schemes:
     - https://datawrapper.dwcdn.net/*
     url: https://api.datawrapper.de/v3/oembed/
-    docs_url: https://developer.datawrapper.de/docs/embedding-charts-via-oembed
+    docs_url: https://developer.datawrapper.de/reference#oembed
     example_urls:
     - https://api.datawrapper.de/v3/oembed/?url=https://datawrapper.dwcdn.net/RnWgL/9/
-    discovery: false
+    discovery: true
     notes: Provider only supports the 'rich' type
 ...


### PR DESCRIPTION
[Datawrapper](https://www.datawrapper.de) is a data visualization service used by many news and media organizations. We're fully supporting the oEmbed specs, documented [here](https://developer.datawrapper.de/reference#oembed).