### PR TITLE
Add soundcloud link shortener domain

### DIFF
--- a/providers/soundcloud.yml
+++ b/providers/soundcloud.yml
@@ -5,6 +5,7 @@
   - schemes:
     - http://soundcloud.com/*
     - https://soundcloud.com/*
+    - https://soundcloud.app.goog.gl/*
     url: https://soundcloud.com/oembed
     example_urls:
     - https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fforss%2Fflickermood


### PR DESCRIPTION
SoundCloud is going to start using a link shortener for social sharing. Some platforms (notably Slack, but potentially others) seem to use this list to limit which domains can have the oembed tags, even when the URL is redirected to the official domain.

Adding this scheme in should hopefully fix that issue, at least for our official shortener. 