### PR TITLE
Codepen redirects to HTTPS

### DIFF
--- a/providers/codepen.yml
+++ b/providers/codepen.yml
@@ -5,7 +5,7 @@
   - schemes:
     - http://codepen.io/*
     - https://codepen.io/*
-    url: http://codepen.io/api/oembed
+    url: https://codepen.io/api/oembed
     example_urls:
     - http://codepen.io/api/oembed?url=https://codepen.io/gingerdude/pen/JXwgdK&format=json
 ...


### PR DESCRIPTION
Codepen.io endpoint redirects to HTTPS so we can adapt the provider.