### PR TITLE
Add more schemes for Jovian provider

### DIFF
--- a/providers/jovian.yml
+++ b/providers/jovian.yml
@@ -1,16 +1,20 @@
 ---
 - provider_name: Jovian
-  provider_url: https://jovian.ml/
+  provider_url: https://jovian.ai/
   endpoints:
   - schemes:
     - https://jovian.ml/*
     - https://jovian.ml/viewer*
     - https://*.jovian.ml/*
+    - https://jovian.ai/*
+    - https://jovian.ai/viewer*
+    - https://*.jovian.ai/*
     url: https://api.jovian.ai/oembed.json
-    docs_url: https://jovian-py.readthedocs.io/en/latest/jvn/oembed.html
+    docs_url: https://jovian.ai/docs/api-reference/oembed.html
     example_urls:
     - https://api.jovian.ai/oembed.json?url=https%3A%2F%2Fjovian.ml%2Faakashns%2Fmovielens-fastai
     - https://api.jovian.ai/oembed.json?url=https%3A%2F%2Fjovian.ml%2Faakashns%2F01-pytorch-basics%2Fv%2F7
+    - https://api.jovian.ai/oembed.json?url=https%3A%2F%2Fjovian.ai%2Faakashns%2F01-pytorch-basics%2Fv%2F7
     discovery: true
     notes: Provider only supports the 'rich' type
 ...


### PR DESCRIPTION
We're migrating from jovian.ml to jovian.ai, all the previous embeds will still work. They'll get redirected to jovian.ai

- added jovian.ai domain links
- updated docs site link