### PR TITLE
Add Facebook Page Embed Scheme and URL

### DIFF
--- a/providers/facebook.yml
+++ b/providers/facebook.yml
@@ -25,4 +25,11 @@
     discovery: false
     example_urls:
     - https://graph.facebook.com/v8.0/oembed_video?url=https%3A%2F%2Fwww.facebook.com%2FCDC&access_token=96481
+  - docs_url: https://developers.facebook.com/docs/plugins/oembed
+    schemes:
+    - https://www.facebook.com/*
+    url: https://graph.facebook.com/v8.0/oembed_page
+    discovery: false
+    example_urls:
+    - https://graph.facebook.com/v8.0/oembed_page?url=https%3A%2F%2Fwww.facebook.com%2FCDC&access_token=96481
 ...


### PR DESCRIPTION
Provides the URL for embedding a facebook page as per https://developers.facebook.com/docs/graph-api/reference/oembed-page/