### PR TITLE
Fix missing scheme for Screencast.com

### DIFF
--- a/providers/screencast.com.yml
+++ b/providers/screencast.com.yml
@@ -4,7 +4,7 @@
   endpoints:
   - schemes:
     -  http://www.screncast.com/*
-  - url: https://api.screencast.com/external/oembed
+    url: https://api.screencast.com/external/oembed
     discovery: true
     example_urls:
     - https://api.screencast.com/external/oembed?url=http%3A%2F%2Fwww.screencast.com%2Fusers%2FTechSmith_Media%2Ffolders%2FCamtasia%2Fmedia%2Fd89af74a-3a32-4c9f-8a85-ef83fdb5c39c

--- a/providers/screencast.com.yml
+++ b/providers/screencast.com.yml
@@ -2,6 +2,8 @@
 - provider_name: Screencast.com
   provider_url: http://www.screencast.com/
   endpoints:
+  - schemes:
+    - http://www.screncast.com/*
   - url: https://api.screencast.com/external/oembed
     discovery: true
     example_urls:

--- a/providers/screencast.com.yml
+++ b/providers/screencast.com.yml
@@ -3,7 +3,7 @@
   provider_url: http://www.screencast.com/
   endpoints:
   - schemes:
-    - http://www.screncast.com/*
+    -  http://www.screncast.com/*
   - url: https://api.screencast.com/external/oembed
     discovery: true
     example_urls:


### PR DESCRIPTION
I'm not sure if this is an error in the library I'm using, or in the entry here but I suspect the lack of scheme is what's causing Screencast URLs to not pass the whitelist. This commit fixes that.