### PR TITLE
Codepen.io returns provider as CodePen

### DIFF
--- a/providers/codepen.yml
+++ b/providers/codepen.yml
@@ -1,5 +1,5 @@
 ---
-- provider_name: Codepen
+- provider_name: CodePen
   provider_url: https://codepen.io
   endpoints:
   - schemes:


### PR DESCRIPTION
Fixes #542

I'm not sure if we should have two entries for backward compatibility.