### PR TITLE
facebook: add missing photos url scheme

### DIFF
--- a/providers/facebook.yml
+++ b/providers/facebook.yml
@@ -6,6 +6,7 @@
     schemes:
     - https://www.facebook.com/*/posts/*
     - https://www.facebook.com/*/activity/*
+    - https://www.facebook.com/*/photos/*
     - https://www.facebook.com/photo.php?fbid=*
     - https://www.facebook.com/photos/*
     - https://www.facebook.com/permalink.php?story_fbid=*


### PR DESCRIPTION
Hello,

Not sure why this kind of URLs are not mentioned in Facebook documentation, but they are considered valid:

```bash
https://www.facebook.com/alternate.de/photos/a.391014166661/10156375231596662
```


In fact it's equivalent to:

```bash
https://www.facebook.com/alternate.de/posts/10156375232586662
```