### PR TITLE
Add Giphy clips scheme

### DIFF
--- a/providers/GIPHY.yml
+++ b/providers/GIPHY.yml
@@ -4,6 +4,7 @@
   endpoints:
   - schemes:
     - https://giphy.com/gifs/*
+    - https://giphy.com/clips/*
     - http://gph.is/*
     - https://media.giphy.com/media/*/giphy.gif
     url: https://giphy.com/services/oembed


### PR DESCRIPTION
Giphy has a new scheme that's supported by oEmbed, eg: https://giphy.com/clips/hamlet-jJjb9AUHOiP3nJJMdy

Embed url: https://giphy.com/services/oembed?url=https://giphy.com/clips/hamlet-jJjb9AUHOiP3nJJMdy