### PR TITLE
Using open.spotify.com as main domain for schemes and oembed endpoint

### DIFF
--- a/providers/spotify.yml
+++ b/providers/spotify.yml
@@ -3,10 +3,10 @@
   provider_url: https://spotify.com/
   endpoints:
   - schemes:
-    - https://*.spotify.com/*
+    - https://open.spotify.com/*
     - spotify:*
-    url: https://embed.spotify.com/oembed/
+    url: https://open.spotify.com/oembed/
     example_urls:
-    - https://embed.spotify.com/oembed/?url=https://open.spotify.com/track/2qToAcex0ruZfbEbAy9OhW
-    - https://embed.spotify.com/oembed/?url=spotify%3Aartist:7ae4vgLLhir2MCjyhgbGOQ
+    - https://open.spotify.com/oembed/?url=https://open.spotify.com/track/2qToAcex0ruZfbEbAy9OhW
+    - https://open.spotify.com/oembed/?url=spotify%3Aartist%3A7ae4vgLLhir2MCjyhgbGOQ
 ...


### PR DESCRIPTION
Hello; I'm creating this PR on behalf on Spotify org - I work in the team that maintains the current embed widget.

In this PR we are fixing two issues:
- The `https://*.spotify.com/*` is too broad as we really only support `open.spotify.com` entities; any other URL in other domain is not embeddable
- The `embed.spotify.com` is a deprecated domain that shouldn't be used anymore; we are already redirecting now from `embed.spotify.com` to `open.spotify.com`

```sh
curl https://embed.spotify.com/oembed\?url\=https://open.spotify.com/track/2qToAcex0ruZfbEbAy9OhW -v -o /dev/null 2>&1 | grep location
* successfully set certificate verify locations:
< location: https://open.spotify.com/oembed?url=https://open.spotify.com/track/2qToAcex0ruZfbEbAy9OhW
```