### PR TITLE
Fix Raindrop provider schema URLs

### DIFF
--- a/providers/raindrop.yml
+++ b/providers/raindrop.yml
@@ -4,8 +4,13 @@
   endpoints:
   - schemes:
     - https://raindrop.io/*
+    - https://raindrop.io/*/*
+    - https://raindrop.io/*/*/*
+    - https://raindrop.io/*/*/*/*
     url: https://pub.raindrop.io/api/oembed
     example_urls:
     - https://pub.raindrop.io/api/oembed?url=https://raindrop.io/exentrich/design-66
     discovery: true
+    formats:
+    - json
 ...


### PR DESCRIPTION
At first I thought that /* one wildcard symbol is enough to support all nested paths. But unfortunately after testing it in https://oembed.link/ nested web pages from Raindrop web site are not working.
This commit fix the problem