### PR TITLE
updating Twitter oembed urls

### DIFF
--- a/providers/twitter.yml
+++ b/providers/twitter.yml
@@ -5,12 +5,10 @@
   - schemes:
     - https://twitter.com/*/status/*
     - https://*.twitter.com/*/status/*
-    - https://twitter.com/*/moments/*
-    - https://*.twitter.com/*/moments/*
     url: https://publish.twitter.com/oembed
-    docs_url: https://dev.twitter.com/rest/reference/get/statuses/oembed
+    docs_url: https://developer.twitter.com/en/docs/twitter-for-websites/oembed-api
     example_urls:
-    - https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2FInterior%2Fstatus%2F507185938620219395
-    - https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2Fi%2Fmoments%2F650667182356082688
+    - https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2FInterior%2Fstatus%2F463440424141459456
+    - https://publish.twitter.com/oembed?url=https%3A%2F%2Ftwitter.com%2FInterior%2Fstatus%2F463440424141459456
 
 ...


### PR DESCRIPTION
Hello! I work on the embed team at Twitter. We recently announced that we're deprecating the moments oembed API, which is referenced in this spec. Our documentation has also moved. The changes I made are to cleanup the information listed about Twitter. Please feel free to reach out to me on Twitter (@/oihamza) if you have any questions. 

https://twittercommunity.com/t/removing-support-for-embedded-like-collection-and-moment-timelines/150313
