### PR TITLE
Update Replit to use .com

### DIFF
--- a/providers/replit.yml
+++ b/providers/replit.yml
@@ -8,6 +8,6 @@
     url: https://replit.com/data/oembed
     docs_url: https://docs.replit.com/hosting/embedding-repls
     example_urls:
-    - https://repl.it/data/oembed/?url=https://replit.com/@replitfaris/python-hello-world
+    - https://replit.com/data/oembed/?url=https://replit.com/@replitfaris/python-hello-world
     discovery: true
 ...


### PR DESCRIPTION
We moved from repl.it to replit.com, https://blog.replit.com/dotcom

I updated the URLs to point to replit.com instead of repl.it. I left the old repl.it scheme since it should still redirect.