### PR TITLE
Add support for Instagram reels

### DIFF
--- a/providers/instagram.yml
+++ b/providers/instagram.yml
@@ -23,6 +23,12 @@
       - https://instagr.am/tv/*
       - https://www.instagram.com/tv/*
       - https://www.instagr.am/tv/*
+      - http://www.instagram.com/reel/*
+      - https://www.instagram.com/reel/*
+      - http://instagram.com/reel/*
+      - https://instagram.com/reel/*
+      - http://instagr.am/reel/*
+      - https://instagr.am/reel/*
     url: https://graph.facebook.com/v10.0/instagram_oembed
     docs_url: https://developers.facebook.com/docs/instagram/oembed
     example_urls:


### PR DESCRIPTION
Haven't found any official announcement or documentation about this, but noticed that the new(ish) Reels feature (https://about.instagram.com/blog/announcements/introducing-instagram-reels-announcement) does not work with Drupal's OEmbed implementation. Users of the OEmbed Plus Wordpress plugin have apparently hit this as well: https://about.instagram.com/blog/announcements/introducing-instagram-reels-announcement (note that I myself am not familiar with this plugin).

Manually modifying a local providers.json to add these new URL schemes makes the embedding work fine, so as far as I can tell Instagram *does* support it, it's just not documented anywhere.