### PR TITLE
Add missing url from Twitter

### DIFF
--- a/providers/flickr.yml
+++ b/providers/flickr.yml
@@ -7,6 +7,8 @@
     - http://flic.kr/p/*
     - https://*.flickr.com/photos/*
     - https://flic.kr/p/*
+    - https://*.*.flickr.com/*/*
+    - http://*.*.flickr.com/*/*
     url: https://www.flickr.com/services/oembed/
     example_urls:
     - https://flickr.com/services/oembed?url=http%3A%2F%2Fflickr.com%2Fphotos%2Fbees%2F2362225867%2F

--- a/providers/twitter.yml
+++ b/providers/twitter.yml
@@ -3,6 +3,7 @@
   provider_url: http://www.twitter.com/
   endpoints:
   - schemes:
+    - https://twitter.com/*
     - https://twitter.com/*/status/*
     - https://*.twitter.com/*/status/*
     url: https://publish.twitter.com/oembed

--- a/providers/wordpress.com.yml
+++ b/providers/wordpress.com.yml
@@ -11,7 +11,7 @@
     - http://*.*.wordpress.com/*
     - https://wp.me/*
     - http://wp.me/*
-  - url: http://public-api.wordpress.com/oembed/
+    url: http://public-api.wordpress.com/oembed/
     docs_url: https://developer.wordpress.com/docs/oembed-provider-api/
     example_urls:
     - https://public-api.wordpress.com/oembed/1.0/?format=json&url=http%3A%2F%2Fmatt.wordpress.com%2F2011%2F07%2F14%2Fclouds-over-new-york%2F&for=oembed.com

--- a/providers/wordpress.com.yml
+++ b/providers/wordpress.com.yml
@@ -1,10 +1,19 @@
 ---
 - provider_name: WordPress.com
-  provider_url: http://wordpress.com/
+  provider_url: https://wordpress.com/
   endpoints:
+  - schemes:
+    - https://wordpress.com/*
+    - http://wordpress.com/*
+    - https://*.wordpress.com/*
+    - http://*.wordpress.com/*
+    - https://*.*.wordpress.com/*
+    - http://*.*.wordpress.com/*
+    - https://wp.me/*
+    - http://wp.me/*
   - url: http://public-api.wordpress.com/oembed/
-    docs_url: http://develop.wordpress.com/oembed-provider-api/
+    docs_url: https://developer.wordpress.com/docs/oembed-provider-api/
     example_urls:
-    - http://public-api.wordpress.com/oembed/1.0/?format=json&url=http%3A%2F%2Fmatt.wordpress.com%2F2011%2F07%2F14%2Fclouds-over-new-york%2F&for=oembed.com
+    - https://public-api.wordpress.com/oembed/1.0/?format=json&url=http%3A%2F%2Fmatt.wordpress.com%2F2011%2F07%2F14%2Fclouds-over-new-york%2F&for=oembed.com
     discovery: true
 ...


### PR DESCRIPTION
- `https://twitter.com/*`

Matching: 

- https://publish.twitter.com/oembed?url=https://twitter.com/TwitterDev
- https://publish.twitter.com/oembed?url=https://twitter.com/TwitterDev/lists/national-parks
