### PR TITLE
Harmonize the Chainflix domain pattern with others

### DIFF
--- a/providers/chainflix.yml
+++ b/providers/chainflix.yml
@@ -5,8 +5,8 @@
   - schemes:
     - https://chainflix.net/video/?*
     - https://chainflix.net/video/embed/?*
-    - https://(m|www).chainflix.net/video/?*
-    - https://(m|www).chainflix.net/video/embed/?*
+    - https://*.chainflix.net/video/?*
+    - https://*.chainflix.net/video/embed/?*
     url: https://www.chainflix.net/video/oembed
     discovery: true
     example_urls:


### PR DESCRIPTION
Seems like all the other providers needing to have multiple subdomains (m. and www. on top of the root domain) are using domain.com plus *.domain.com approach. Let's stick to the same pattern with Chainflix too.

This would also fix the [Chainflix oEmbed issue](https://www.drupal.org/project/drupal/issues/3256828) appearing in Drupal after #607 was merged.