### PR TITLE
Fix Chainflix URL patterns

### DIFF
--- a/providers/chainflix.yml
+++ b/providers/chainflix.yml
@@ -3,10 +3,10 @@
   provider_url: https://chainflix.net
   endpoints:
   - schemes:
-    - https://chainflix.net/video/?*
-    - https://chainflix.net/video/embed/?*
-    - https://*.chainflix.net/video/?*
-    - https://*.chainflix.net/video/embed/?*
+    - https://chainflix.net/video/*
+    - https://chainflix.net/video/embed/*
+    - https://*.chainflix.net/video/*
+    - https://*.chainflix.net/video/embed/*
     url: https://www.chainflix.net/video/oembed
     discovery: true
     example_urls:


### PR DESCRIPTION
In addition to the #608 the `?*` at the end of the URL pattern will mess up regex handling and is not in line with other provider URL patterns. See `curl -s https://oembed.com/providers.json | grep "\/\*\."` All the others have simply domain.com/some-path/*

See comments in the PR #608