### PR TITLE
Added Amtraker (amtraker.com) as provider.

### DIFF
--- a/providers/amtraker.yml
+++ b/providers/amtraker.yml
@@ -1,0 +1,22 @@
+---
+- provider_name: Amtraker
+  provider_url: https://amtraker.com
+  endpoints:
+  - schemes:
+    - https://amtraker.com/view.html*
+    - https://www.amtraker.com/view.html*
+    - https://beta.amtraker.com/view.html*
+    - https://whereismytrain.us/view.html*
+    - https://www.whereismytrain.us/view.html*
+    - https://whereismyfuckingtrain.com/view.html*
+    - https://www.whereismyfuckingtrain.com/view.html*
+    - https://amtrak.cc/view.html*
+    - https://www.amtrak.cc/view.html*
+    url: https://api.amtrak.cc/v2/oembed
+    docs_url: https://api.amtrak.cc/docs
+    example_urls:
+    - https://api.amtrak.cc/v2/oembed?url=https://amtraker.com/view.html?train=123456
+    - https://api.amtrak.cc/v2/oembed?url=https://whereismyfuckingtrain.com/view.html?train=123456&xml=true
+    discovery: false
+    notes: Provider only supports the 'rich' type. Sample train number may not always work, see docs for details.
+...


### PR DESCRIPTION
Amtraker is a web-based tool to track amtrak trains. The provided oEmbed configuration would end up displaying something like this:

![Screen Shot 2022-01-06 at 23 55 14](https://user-images.githubusercontent.com/22846928/148498828-d5e6a3fa-b0ea-4ad5-8ce0-24933529b6c9.png)

