### PR TITLE
Update endpoints for Sway, Spotify and YouTube

### DIFF
--- a/providers/spotify.yml
+++ b/providers/spotify.yml
@@ -5,7 +5,7 @@
   - schemes:
     - https://open.spotify.com/*
     - spotify:*
-    url: https://open.spotify.com/oembed/
+    url: https://open.spotify.com/oembed
     discovery: true
     example_urls:
     - https://open.spotify.com/oembed/?url=https://open.spotify.com/track/2qToAcex0ruZfbEbAy9OhW

--- a/providers/sway.yml
+++ b/providers/sway.yml
@@ -5,7 +5,6 @@
   - schemes:
     - https://sway.com/*
     - https://www.sway.com/*
-    - https://sway.office.com/*
     url: https://sway.com/api/v1.0/oembed
     example_urls:
     - https://sway.com/api/v1.0/oembed?url=https%3a%2f%2fsway.com%2fmaking_of_wildcat_sculpture&amp;format=json

--- a/providers/sway_office.yaml
+++ b/providers/sway_office.yaml
@@ -1,0 +1,11 @@
+---
+- provider_name: Sway Office
+  provider_url: https://sway.office.com
+  endpoints:
+  - schemes:
+    - https://sway.office.com/*
+    url: https://sway.office.com/api/v1.0/oembed
+    example_urls:
+    - https://sway.office.com/api/v1.0/oembed?url=https%3a%2f%2fsway.office.com/ZCftQ83K9iHgOCH0&amp;format=json
+    discovery: true
+...

--- a/providers/youtube.yml
+++ b/providers/youtube.yml
@@ -8,6 +8,7 @@
     - https://youtu.be/*
     - https://*.youtube.com/playlist?list=*
     - https://youtube.com/playlist?list=*
+    - https://*.youtube.com/shorts*
     url: https://www.youtube.com/oembed
     discovery: true
     example_urls:
@@ -15,4 +16,5 @@
     - https://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DiwGFalTRHDA&format=xml
     - https://www.youtube.com/oembed?url=http%3A%2F%2Fwww.youtube.com%2Fplaylist%3Flist%3DPLSL0f2Dh_snCsLgQ3J319RYQyctRlfJFc
     - https://www.youtube.com/oembed?url=https%3A%2F%2Fyoutube.com%2Fplaylist%3Flist%3DPLpeDXSh4nHjRmry7-h62UHfo86evvMK7E
+    - https://www.youtube.com/oembed?url=https://www.youtube.com/shorts/a12CpYea0i4
 ...


### PR DESCRIPTION
Change logs:

- Separate Sway Office from Sway ( #621, ndaidong/oembed-parser#125 ndaidong/oembed-parser#130)
- Fix Spotify oEmbed URL (ndaidong/oembed-parser#133)
- Add YouTube Shorts endpoint (ndaidong/oembed-parser#131)