### PR TITLE
Update Audioboom scheme

### DIFF
--- a/providers/audioboom.yml
+++ b/providers/audioboom.yml
@@ -5,16 +5,20 @@
   - schemes:
     - https://audioboom.com/channels/*
     - https://audioboom.com/channel/*
+    - https://audioboom.com/playlists/*
+    - https://audioboom.com/podcasts/*
+    - https://audioboom.com/podcast/*
     - https://audioboom.com/posts/*
-    url: https://audioboom.com/publishing/oembed/v4.{format}
+    - https://audioboom.com/episodes/*
+    url: https://audioboom.com/publishing/oembed.{format}
     formats:
     - json
     - xml
     example_urls:
-    - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
-    - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
-    - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
-    - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
-    - https://audioboom.com/publishing/oembed/v4.json?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
-    - https://audioboom.com/publishing/oembed/v4.xml?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
+    - https://audioboom.com/publishing/oembed.json?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
+    - https://audioboom.com/publishing/oembed.xml?url=https%3A%2F%2Faudioboom.com%2Fchannels%2F4971939
+    - https://audioboom.com/publishing/oembed.json?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
+    - https://audioboom.com/publishing/oembed.xml?url=https%3A%2F%2Faudioboom.com%2Fchannel%2Fcasefile-true-crime
+    - https://audioboom.com/publishing/oembed.json?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
+    - https://audioboom.com/publishing/oembed.xml?url=https%3A%2F%2Faudioboom.com%2Fposts%2F7193185-stephen-merchant
 ...


### PR DESCRIPTION
Audioboom's default oembed endpoint shouldn't be locked to a version number