### PR TITLE
Add miro.com to providers

### DIFF
--- a/providers/miro.yml
+++ b/providers/miro.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Miro
+  provider_url: https://miro.com/
+  endpoints:
+  - schemes:
+    - https://miro.com/app/board/*
+    url: https://miro.com/api/v1/oembed
+    discovery: true
+    example_urls:
+    - https://miro.com/api/v1/oembed?url=https://miro.com/app/board/uXjVPZH3NrA=/
+    notes: This provider only supports the 'rich' type.
+...


### PR DESCRIPTION
Adds a single scheme for embedding Miro boards.