### PR TITLE
Add Mixpanel provider

### DIFF
--- a/providers/mixpanel.yml
+++ b/providers/mixpanel.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Mixpanel
+  provider_url: https://mixpanel.com/
+  endpoints:
+  - schemes:
+    - https://www.mixpanel.com/*
+    url: https://mixpanel.com/api/app/embed/oembed/
+    docs_url: https://developer.mixpanel.com/docs
+    example_urls:
+    - https://mixpanel.com/api/app/embed/oembed?url=https%3A%2F%2Fmixpanel.com%2Fs%2F4mEW4a
+    - https://mixpanel.com/api/app/embed/oembed/?url=https%3A%2F%2Fmixpanel.com%2Fproject%2F2195193%2Fview%2F139237%2Fapp%2Fdashboards%23id%3D685944%26editor-card-id%3D%2522report-link-4409611%2522%27
+
+...

--- a/providers/mixpanel.yml
+++ b/providers/mixpanel.yml
@@ -3,7 +3,7 @@
   provider_url: https://mixpanel.com/
   endpoints:
   - schemes:
-    - https://www.mixpanel.com/*
+    - https://mixpanel.com/*
     url: https://mixpanel.com/api/app/embed/oembed/
     docs_url: https://developer.mixpanel.com/docs
     example_urls:


### PR DESCRIPTION
Adds Mixpanel oEmbed API to the providers list. This will enable rich Mixpanel report embeds

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/556882/205115362-7a68ddfb-880c-4c7d-b1a6-6fa7fdcb4c72.png">
