### PR TITLE
Fix DeviantArt url schemes

### DIFF
--- a/providers/deviantart.com.yml
+++ b/providers/deviantart.com.yml
@@ -9,7 +9,7 @@
     - http://sta.sh/*
     - https://*.deviantart.com/art/*
     - https://*.deviantart.com/*/art/*
-    - https://sta.sh/*,
+    - https://sta.sh/*
     - https://*.deviantart.com/*#/d*
     url: http://backend.deviantart.com/oembed
     docs_url: https://www.deviantart.com/developers/oembed

--- a/providers/deviantart.com.yml
+++ b/providers/deviantart.com.yml
@@ -9,8 +9,8 @@
     - http://sta.sh/*
     - https://*.deviantart.com/art/*
     - https://*.deviantart.com/*/art/*
-    - https://sta.sh/*",
-    - https://*.deviantart.com/*#/d*"
+    - https://sta.sh/*,
+    - https://*.deviantart.com/*#/d*
     url: http://backend.deviantart.com/oembed
     docs_url: https://www.deviantart.com/developers/oembed
     example_urls:


### PR DESCRIPTION
This removes trailing `"` and `,` from url schemes. Those chars are seems typo.