### PR TITLE
Create new Provider: FlowHub.org

### DIFF
--- a/providers/FlowHubOrg.yml
+++ b/providers/FlowHubOrg.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: FlowHubOrg
+  provider_url: https://flows.flowhub.org
+  endpoints:
+  - url: https://flowhub.org/o/embed
+    schemes:
+      - https://flowhub.org/f/*
+      - https://flowhub.org/s/*
+    discovery: true
+    example_urls:
+      - https://flowhub.org/o/embed?url=https%3A//flowhub.org/f/390ee0021ded4910
+      - https://flowhub.org/o/embed?url=https%3A//flowhub.org/f/390ee0021ded4910
+...

--- a/providers/FlowHubOrg.yml
+++ b/providers/FlowHubOrg.yml
@@ -9,5 +9,5 @@
     discovery: true
     example_urls:
       - https://flowhub.org/o/embed?url=https%3A//flowhub.org/f/390ee0021ded4910
-      - https://flowhub.org/o/embed?url=https%3A//flowhub.org/f/390ee0021ded4910
+      - https://flowhub.org/o/embed?url=https%3A//flowhub.org/f/f21aed28a04a7fd0
 ...


### PR DESCRIPTION
[FlowHub.org](https://flows.flowhub.org) is site hosting example [Node-RED](https://nodered.org) flows for providing an educational resource for those wanting to learn Node-RED.