### PR TITLE
add Bluesky provider YAML file

### DIFF
--- a/providers/bluesky.yml
+++ b/providers/bluesky.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Bluesky Social
+  provider_url: https://bsky.app
+  endpoints:
+    - schemes:
+        - https://bsky.app/profile/*/post/*
+      url: https://embed.bsky.app/oembed
+      example_urls:
+        - https://embed.bsky.app/oembed?format=json&url=https%3A%2F%2Fbsky.app%2Fprofile%2Fdid%3Aplc%3Avjug55kidv6sye7ykr5faxxn%2Fpost%2F3jzn6g7ixgq2y
+        - https://embed.bsky.app/oembed?format=json&url=https%3A%2F%2Fbsky.app%2Fprofile%2Femilyliu.me%2Fpost%2F3jzn6g7ixgq2y
+      discovery: true
+...


### PR DESCRIPTION
Bluesky recently added public embed support, including oEmbed discovery.

There is a tool to generate and experiment with embeds at https://embed.bsky.app

The source code for this embed service, the JS widget, and our web app client generally, is available at: https://github.com/bluesky-social/social-app