### PR TITLE
Add YouTube short share provider without www prefix

### DIFF
--- a/providers/youtube.yml
+++ b/providers/youtube.yml
@@ -9,6 +9,7 @@
     - https://*.youtube.com/playlist?list=*
     - https://youtube.com/playlist?list=*
     - https://*.youtube.com/shorts*
+    - https://youtube.com/shorts*    
     - https://*.youtube.com/embed/*
     url: https://www.youtube.com/oembed
     discovery: true


### PR DESCRIPTION
Full issue description: https://github.com/iamcal/oembed/issues/759

