### PR TITLE
Add mysqlexplain provider

### DIFF
--- a/providers/mysqlexplain.yml
+++ b/providers/mysqlexplain.yml
@@ -1,0 +1,15 @@
+---
+- provider_name: MySQL Visual Explain
+  provider_url: https://mysqlexplain.com
+  endpoints:
+  - schemes:
+    - https://mysqlexplain.com/explain/*
+    - https://embed.mysqlexplain.com/explain/*
+    url: https://api.mysqlexplain.com/v2/oembed.json
+    example_urls:
+    - https://api.mysqlexplain.com/v2/oembed.json?url=https%3A%2F%2Fmysqlexplain.com%2Fexplain%2F01j2ef1bj7efr97m5v140rnxyz
+    formats:
+      - json
+    discovery: true
+    notes: Provider only supports the 'rich' type.
+...


### PR DESCRIPTION
Hi @iamcal , I've built [mysqlexplain.com](https://mysqlexplain.com) to give developers a tool for easier MySQL query performance debugging. I want to join the providers list so that these interactive diagrams can be easily embed in blogs. Please let me know if there is something wrong on this change. Thanks :)