### PR TITLE
Update the API to recognise spotify.link URLs

### DIFF
--- a/providers/spotify.yml
+++ b/providers/spotify.yml
@@ -5,6 +5,7 @@
   - schemes:
     - https://open.spotify.com/*
     - spotify:*
+    - https://spotify.link/*
     url: https://open.spotify.com/oembed
     discovery: true
     docs_url: https://developer.spotify.com/documentation/embeds/reference/oembed


### PR DESCRIPTION
Hello. I'm creating this PR on behalf on Spotify org - I work in the team that maintains the current embed widget.

In this PR we want to add support for Spotify's short links domain, like this example https://spotify.link/wd8v9BNGbMb.