### PR TITLE
add Framatube

### DIFF
--- a/providers/framatube.yml
+++ b/providers/framatube.yml
@@ -1,0 +1,8 @@
+---
+- provider_name: Framatube
+  provider_url: https://framatube.org/
+  endpoints:
+  - schemes:
+    - https://framatube.org/w/*
+    url: https://framatube.org/services/oembed
+...


### PR DESCRIPTION
[Framatube](https://framatube.org) is a [PeerTube](https://joinpeertube.org/) instance created and maintained by [Framasoft](https://framasoft.org/), the company behind PeerTube.