### PR TITLE
Add Webcrumbs oEmbed Provider

### DIFF
--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -9,8 +9,8 @@
     url: http://share.webcrumbs.org/
     docs_url: https://github.com/webcrumbs-community/webcrumbs
     example_urls:
-    - http://share.webcrumbs.org/Pd6r5O?embed=json
-    - http://share.webcrumbs.org/Pd6r5O?embed=xml
+    - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=json
+    - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=xml
     discovery: true
     notes: Provider only supports the 'rich' type
 ...

--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -1,10 +1,16 @@
+---
 - provider_name: Webcrumbs
   provider_url: https://webcrumbs.org/
   endpoints:
   - schemes:
-    - http://share.webcrumbs.org/*
-  url: http://share.webcrumbs.org/
-  discovery: true
-  example_urls:
+    - https://share.webcrumbs.org/*
+    - https://tools.webcrumbs.org/*
+    - https://www.webcrumbs.org/*
+    url: http://share.webcrumbs.org/
+    docs_url: https://github.com/webcrumbs-community/webcrumbs
+    example_urls:
     - http://share.webcrumbs.org/Pd6r5O?embed=json
     - http://share.webcrumbs.org/Pd6r5O?embed=xml
+    discovery: true
+    notes: Provider only supports the 'rich' type
+...

--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -1,0 +1,10 @@
+- provider_name: Webcrumbs
+  provider_url: https://webcrumbs.org/
+  endpoints:
+  - schemes:
+    - http://share.webcrumbs.org/*
+  url: http://share.webcrumbs.org/
+  discovery: true
+  example_urls:
+    - http://share.webcrumbs.org/Pd6r5O?embed=json
+    - http://share.webcrumbs.org/Pd6r5O?embed=xml


### PR DESCRIPTION
This PR adds Webcrumbs as an oEmbed provider. Webcrumbs supports rich embeds via shortlinks and provides both JSON and XML responses.