### PR TITLE
Allow all subdomains for Mixpanel provider

### DIFF
--- a/providers/mixpanel.yml
+++ b/providers/mixpanel.yml
@@ -4,10 +4,12 @@
   endpoints:
   - schemes:
     - https://mixpanel.com/*
+    - https://*.mixpanel.com/*
     url: https://mixpanel.com/api/app/embed/oembed/
     docs_url: https://developer.mixpanel.com/docs
     example_urls:
     - https://mixpanel.com/api/app/embed/oembed?url=https%3A%2F%2Fmixpanel.com%2Fs%2F4mEW4a
+    - https://mixpanel.com/api/app/embed/oembed?url=https%3A%2F%2Fin.mixpanel.com%2Fs%2F1nGsfj&format=json
     - https://mixpanel.com/api/app/embed/oembed/?url=https%3A%2F%2Fmixpanel.com%2Fproject%2F2195193%2Fview%2F139237%2Fapp%2Fdashboards%23id%3D685944%26editor-card-id%3D%2522report-link-4409611%2522%27
 
 ...


### PR DESCRIPTION
Mixpanel has regional subdomains that should be explicitly embeddable, eg https://eu.mixpanel.com and https://in.mixpanel.com

I specified a subdomain wildcard to futureproof it.