### PR TITLE
Extra comma for some instagram values

### DIFF
--- a/providers/instagram.yml
+++ b/providers/instagram.yml
@@ -3,10 +3,10 @@
   provider_url: https://instagram.com
   endpoints:
   - schemes:
-      - http://instagram.com/*/p/*,
-      - http://www.instagram.com/*/p/*,
-      - https://instagram.com/*/p/*,
-      - https://www.instagram.com/*/p/*,
+      - http://instagram.com/*/p/*
+      - http://www.instagram.com/*/p/*
+      - https://instagram.com/*/p/*
+      - https://www.instagram.com/*/p/*
       - http://instagram.com/p/*
       - http://instagr.am/p/*
       - http://www.instagram.com/p/*


### PR DESCRIPTION
Could it be that there's an extra comma for posts that include the user?

I think these got in in #411 but I cannot validate something like https://www.instagram.com/el_pais/p/DCmx8XbzFk1/, I might be missing something but I don't see any other with commas.