### PR TITLE
Add Skoletube.dk and Bornetube.dk as providers

### DIFF
--- a/providers/bornetube.yml
+++ b/providers/bornetube.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Bornetube
+  provider_url: https://www.bornetube.dk/
+  endpoints:
+  - schemes:
+    - https://www.bornetube.dk/media/*
+    - https://www.bornetube.dk/video/*
+    url: https://www.bornetube.dk/media/lasync/oembed/
+    discovery: true
+    example_urls:
+    - https://www.skoletube.dk/media/lasync/oembed/?url=https%3A%2F%2Fwww.bornetube.dk%2Fmedia%2F1345406%2F91hxqgvbcdn32niy9d4hq8r4dxyg8xvb1ebm719f
+    - https://www.skoletube.dk/media/lasync/oembed/?url=https%3A%2F%2Fwww.bornetube.dk%2Fmedia%2F1345406%2F91hxqgvbcdn32niy9d4hq8r4dxyg8xvb1ebm719f&format=xml
+...

--- a/providers/skoletube.yml
+++ b/providers/skoletube.yml
@@ -1,0 +1,15 @@
+---
+- provider_name: Skoletube
+  provider_url: https://www.skoletube.dk/
+  endpoints:
+  - schemes:
+    - https://www.skoletube.dk/media/*
+    - https://www.skoletube.dk/video/*
+    - https://www.studietube.dk/media/*
+    - https://www.studietube.dk/video/*
+    url: https://www.skoletube.dk/media/lasync/oembed/
+    discovery: true
+    example_urls:
+    - https://www.skoletube.dk/media/lasync/oembed/?url=https%3A%2F%2Fwww.skoletube.dk%2Fmedia%2F9488982%2F1gaxieybl2mw5necqt8f0aewjm6n0blctkfi4soz
+    - https://www.skoletube.dk/media/lasync/oembed/?url=https%3A%2F%2Fwww.skoletube.dk%2Fmedia%2F9488982%2F1gaxieybl2mw5necqt8f0aewjm6n0blctkfi4soz&format=xml
+...


### PR DESCRIPTION
Skoletube and Bornetube are media platforms for kids in schools and kinder gardens in Denmark.

Our media platform sites:
https://www.skoletube.dk
https://www.bornetube.dk

Our business site:
https://laerit.dk