### PR TITLE
Use application/json MIME type

### DIFF
--- a/www/json.php
+++ b/www/json.php
@@ -1,5 +1,5 @@
 <?php
-	header('Content-type: text/plain; charset=utf-8');
+	header('Content-type: application/json; charset=utf-8');
 
 
 	#


### PR DESCRIPTION
The JSON file is currently not served as JSON.
This would make it easier to inspect it in Firefox for example.