### PR TITLE
Add Satcat as Provider

### DIFF
--- a/providers/satcat.yml
+++ b/providers/satcat.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Satcat
+  provider_url: https://www.satcat.com/
+  endpoints:
+    - schemes:
+        - https://www.satcat.com/sats/*
+      url: https://www.satcat.com/api/sats/oembed
+      discovery: true
+      example_urls:
+        - https://www.satcat.com/api/sats/oembed?url=https%3A%2F%2Fwww.satcat.com%2Fsats%2F25544
+        - https://www.satcat.com/api/sats/oembed?url=https%3A%2F%2Fwww.satcat.com%2Fsats%2F58651
+        - https://www.satcat.com/api/sats/oembed?url=https%3A%2F%2Fwww.satcat.com%2Fsats%2F62430


### PR DESCRIPTION
Adding Satcat.com as a new provider.

Example: https://debug.iframely.com/?uri=https%3A%2F%2Fwww.satcat.com%2Fsats%2F25544

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/b357733f-2ba5-43d9-b7ca-395fa4d4a3f5" />
