### PR TITLE
sooplive uses the same provider_name as afreecatv

### DIFF
--- a/providers/sooplive.yml
+++ b/providers/sooplive.yml
@@ -1,5 +1,5 @@
 ---
-- provider_name: afreecaTV
+- provider_name: SOOP
   provider_url: https://www.sooplive.co.kr
   endpoints:
   - schemes:


### PR DESCRIPTION
The sooplive provider currently uses the same 'provider_name' value as afreecatv.

It seems like a copy+paste errror when adding the provider, as SOOP was previously known as AfreecaTV. afreecatv.com now redirects to sooplive.co.kr.