### PR TITLE
Update webcrumbs.yml

### DIFF
--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -7,7 +7,6 @@
     - https://tools.webcrumbs.org/*
     - https://www.webcrumbs.org/*
     url: http://share.webcrumbs.org/
-    docs_url: https://github.com/webcrumbs-community/webcrumbs
     example_urls:
     - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=json
     - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=xml


### PR DESCRIPTION
We're updating this oEmbed provider definition because we've launched a new version of the Webcrumbs Plugin repository. The new version makes it easier for users to create and share embeddable JavaScript plugins with no setup required. This update ensures our oEmbed endpoint reflects the current structure and fully supports rich embeds from plugin URLs, including discovery and JSON/XML responses.

Edit: Removed `docs_url` that was conflicting with `test.php`