### PR TITLE
Update webcrumbs.yml

### DIFF
--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -1,16 +1,16 @@
 ---
 - provider_name: Webcrumbs
   provider_url: https://webcrumbs.org/
+  docs_url: https://github.com/webcrumbs-community/webcrumbs
   endpoints:
   - schemes:
-    - https://share.webcrumbs.org/*
-    - https://tools.webcrumbs.org/*
-    - https://www.webcrumbs.org/*
-    url: http://share.webcrumbs.org/
-    docs_url: https://github.com/webcrumbs-community/webcrumbs
+      - https://plugins.webcrumbs.dev/*
+    url: https://webcrumbs.dev/oembed
+    formats:
+      - json
+      - xml
     example_urls:
-    - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=json
-    - http://share.webcrumbs.org/Pd6r5O?url=http://share.webcrumbs.org/Pd6r5O&embed=xml
+      - https://plugins.webcrumbs.dev/demo-component
     discovery: true
     notes: Provider only supports the 'rich' type
 ...

--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -1,16 +1,16 @@
 ---
 - provider_name: Webcrumbs
   provider_url: https://webcrumbs.org/
-  docs_url: https://github.com/webcrumbs-community/webcrumbs
   endpoints:
   - schemes:
-      - https://plugins.webcrumbs.dev/*
+    - https://plugins.webcrumbs.dev/*
     url: https://webcrumbs.dev/oembed
+    docs_url: https://github.com/webcrumbs-community/webcrumbs
     formats:
-      - json
-      - xml
+    - json
+    - xml
     example_urls:
-      - https://plugins.webcrumbs.dev/demo-component
+    - https://plugins.webcrumbs.dev/demo-component
     discovery: true
     notes: Provider only supports the 'rich' type
 ...

--- a/providers/webcrumbs.yml
+++ b/providers/webcrumbs.yml
@@ -10,7 +10,8 @@
     - json
     - xml
     example_urls:
-    - https://plugins.webcrumbs.dev/demo-component
+    - https://webcrumbs.dev/oembed?url=https://plugins.webcrumbs.dev/demo-component&format=json
+    - https://webcrumbs.dev/oembed?url=https://plugins.webcrumbs.dev/demo-component&format=xml
     discovery: true
     notes: Provider only supports the 'rich' type
 ...


### PR DESCRIPTION
We're updating this oEmbed provider definition because we've launched a new version of the Webcrumbs Plugin repository. The new version makes it easier for users to create and share embeddable JavaScript plugins with no setup required. This update ensures our oEmbed endpoint reflects the current structure and fully supports rich embeds from plugin URLs, including discovery and JSON/XML responses.

Edit: Repositioned docs_url and fixed example_urls that were conflicting with test.php