### PR TITLE
Updated oEmbed to handle Sudomemo's Flipnote Archive

### DIFF
--- a/providers/sudomemo.yml
+++ b/providers/sudomemo.yml
@@ -5,11 +5,14 @@
   - schemes:
     - 'https://www.sudomemo.net/watch/*'
     - 'http://www.sudomemo.net/watch/*'
+    - 'https://archive.sudomemo.net/watch/*'
+    - 'http://archive.sudomemo.net/watch/*'
     - 'https://flipnot.es/*'
     - 'http://flipnot.es/*'
     url: 'https://www.sudomemo.net/oembed'
     example_urls:
     - 'https://www.sudomemo.net/oembed?url=https%3A%2F%2Fflipnot.es%2F8UYNV9&format=json'
     - 'https://www.sudomemo.net/oembed?url=https%3A%2F%2Fwww.sudomemo.net%2Fwatch%2F75D7C9_135509C9F1AA8_000&format=json'
+    - 'https://www.sudomemo.net/oembed?url=https%3A%2F%2Farchive.sudomemo.net%2Fwatch%2Fmbwciwgtrf0ehxvtoarwvozbwngc&format=json'
     discovery: true
 ...


### PR DESCRIPTION
After Sudomemo was added to the oEmbed spec in 2020, we released the Flipnote Archive in 2022. The Flipnote Archive is fully implemented into our oEmbed endpoint. Anyway, I figured we ought to get that updated.