### PR TITLE
Update index.php - Adding AWS implementation

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -493,6 +493,7 @@ Link: &lt;http://flickr.com/services/oembed?url=http%3A%2F%2Fflickr.com%2Fphotos
 	<li>Node.js: oEmbed API Gateway (<a href="https://github.com/itteco/iframely">https://github.com/itteco/iframely</a>)</li>
 	<li>Elixir: furlex (<a href="https://github.com/claytongentry/furlex">https://github.com/claytongentry/furlex</a>)</li>
 	<li>Elixir: elixir-oembed (<a href="https://github.com/r8/elixir-oembed">https://github.com/r8/elixir-oembed</a>)</li>
+	<li>AWS: Serverless oEmbed provider (<a href="https://github.com/aws-samples/sample-serverless-oembed">https://github.com/aws-samples/sample-serverless-oembed</a>)</li>
 </ul>
 
 


### PR DESCRIPTION
Adding a new link to the Library section.

This new link points to a new github project release by AWS under aws-samples:
https://github.com/aws-samples/sample-serverless-oembed

It is a serverless oEmbed provider implementation built on AWS.
This implementation fully respects oEmbed standard from oembed.com.
It can be used as boilerplate to easily connect your backend data and deploy an oEmbed endpoint quickly.
API caching is available, it already make use of CDN and It is all serverless, so you pay only for what you use. 

Note:
Maybe this new link could be further down in the page with the Webmonkey tutorial?