### PR TITLE
Update miro.com providers

### DIFF
--- a/providers/miro.yml
+++ b/providers/miro.yml
@@ -9,4 +9,11 @@
     example_urls:
     - https://miro.com/api/v1/oembed?url=https://miro.com/app/board/uXjVPZH3NrA=/
     notes: This provider only supports the 'rich' type.
+  - schemes:
+    - https://miro.com/video-player/*
+    url: https://miro.com/video-player/oembed
+    discovery: true
+    example_urls:
+    - https://miro.com/video-player/oembed?url=https://miro.com/video-player/1234567890
+    notes: This provider only supports the 'video' type.
 ...


### PR DESCRIPTION
From now on, there will be a new scheme `miro.com/video-player` for the Miro provider.