### PR TITLE
Add Programmingly.dev oEmbed provider

### DIFF
--- a/providers/programmingly.dev.yml
+++ b/providers/programmingly.dev.yml
@@ -3,10 +3,10 @@
   provider_url: https://programmingly.dev
   endpoints:
     - schemes:
-        - https://programmingly.dev/snippet/*
+        - https://programmingly.dev/snippets/*
       url: https://programmingly.dev/api/oembed
-      example_urls:
-        - https://programmingly.dev/snippets/easily-convert-php-arrays-or-associative-arrays-to-downloadable-csv-files-in-seconds-SKbBcUsS
-        - https://programmingly.dev/snippets/effortlessly-download-your-table-or-object-data-as-a-csv-file-in-react-or-nextjs-without-any-server-zaOjC12W
-        - https://programmingly.dev/snippets/easily-convert-php-arrays-or-associative-arrays-to-downloadable-csv-files-in-seconds-SKbBcUsS
       discovery: true
+      example_urls:
+        - https://programmingly.dev/api/oembed?format=json&url=https://programmingly.dev/snippets/easily-convert-php-arrays-or-associative-arrays-to-downloadable-csv-files-in-seconds-SKbBcUsS
+        - https://programmingly.dev/api/oembed?format=json&url=https://programmingly.dev/snippets/effortlessly-download-your-table-or-object-data-as-a-csv-file-in-react-or-nextjs-without-any-server-zaOjC12W
+        - https://programmingly.dev/api/oembed?format=json&url=https://programmingly.dev/snippets/easily-convert-php-arrays-or-associative-arrays-to-downloadable-csv-files-in-seconds-SKbBcUsS


### PR DESCRIPTION
This PR adds Programmingly.dev to the oEmbed providers list.

Our platform allows developers to publish public code snippets and embed them anywhere.
Our oEmbed endpoint supports JSON format and rich embeds.

Endpoint:
https://programmingly.dev/api/oembed

Example public snippet URLs:
https://programmingly.dev/snippets/<slug>
(3 examples included in YAML)

The HTML snippet pages include proper <link rel="alternate"> discovery tags.

Everything is live and production-ready.
