### PR TITLE
fix(figma): update schema to include all new figma page types

### DIFF
--- a/providers/figma.yml
+++ b/providers/figma.yml
@@ -5,7 +5,7 @@
   - schemes:
     - https://www.figma.com/file/*
     - https://www.figma.com/design/*
-    - https://www.figma.com/board/*",
+    - https://www.figma.com/board/*
     - https://www.figma.com/slides/*
     - https://www.figma.com/buzz/*
     - https://www.figma.com/site/*


### PR DESCRIPTION
Update URL patterns to include file, design, board, slides, buzz, site, make


solves https://github.com/iamcal/oembed/issues/843