### PR TITLE
Add Tella video provider

### DIFF
--- a/providers/tella.yml
+++ b/providers/tella.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Tella
+  provider_url: https://www.tella.tv/
+  endpoints:
+  - schemes:
+    - https://www.tella.tv/video/*
+    - https://tella.video/*
+    url: https://www.tella.tv/api/oembed
+    discovery: true
+    example_urls:
+    - https://www.tella.tv/api/oembed?url=https%3A%2F%2Fwww.tella.tv%2Fvideo%2Fabc123%2Fview
+...


### PR DESCRIPTION
## Summary
Add Tella as an OEmbed provider.

**Tella** is a video recording and editing platform that helps teams create professional videos easily.

## Provider Details
- **Provider Name**: Tella
- **Provider URL**: https://www.tella.tv/
- **OEmbed Endpoint**: https://www.tella.tv/api/oembed
- **Discovery**: Enabled (Tella video pages include `<link rel="alternate" type="application/json+oembed">` tags)

## URL Schemes
- `https://www.tella.tv/video/*`
- `https://tella.video/*`

## Testing
The OEmbed endpoint can be tested with:
```
https://www.tella.tv/api/oembed?url=https%3A%2F%2Fwww.tella.tv%2Fvideo%2F{video_id}%2Fview
```

## Checklist
- [x] YAML file follows the existing format
- [x] OEmbed endpoint returns valid JSON response
- [x] Discovery tags are present on video pages