### PR TITLE
Added Juntos.live provider

### DIFF
--- a/providers/juntos.yml
+++ b/providers/juntos.yml
@@ -4,6 +4,7 @@
   endpoints:
   - schemes:
     - https://play.juntos.live/solo/*
+    - https://play.juntos.live/host/quiz/*
     url: https://play.juntos.live/api/oembed
     example_urls:
     - https://play.juntos.live/api/oembed?url=https%3A%2F%2Fplay.juntos.live%2Fsolo%2F2aAD8q0VdfZhJAoxKZYT


### PR DESCRIPTION
Added juntos.live provider.
It is also supported via discoverable meta link. 
Still needed in this repo because some hosts use it as their registry, and don't support dynamic links unless they are here. 