### PR TITLE
Add Embases provider configuration

### DIFF
--- a/providers/embases.yml
+++ b/providers/embases.yml
@@ -1,0 +1,7 @@
+provider_name: Embases
+provider_url: https://embases.com/
+endpoints:
+  - schemes:
+      - https://app.embases.com/e/*
+    url: https://app.embases.com/api/oembed
+    discovery: true

--- a/providers/embases.yml
+++ b/providers/embases.yml
@@ -1,7 +1,11 @@
-provider_name: Embases
-provider_url: https://embases.com/
-endpoints:
+---
+- provider_name: Embases
+  provider_url: https://embases.com/
+  endpoints:
   - schemes:
-      - https://www.embases.com/e/*
+    - https://www.embases.com/e/*
     url: https://www.embases.com/api/oembed
+    example_urls:
+    - https://www.embases.com/api/oembed?url=https%3A%2F%2Fwww.embases.com%2Fe%2F142fa3242a5f5ed7db3821e7c8d349ec738e8facf7905e32d987df4165ccb3d6&format=json
     discovery: true
+...

--- a/providers/embases.yml
+++ b/providers/embases.yml
@@ -2,6 +2,6 @@ provider_name: Embases
 provider_url: https://embases.com/
 endpoints:
   - schemes:
-      - https://app.embases.com/e/*
-    url: https://app.embases.com/api/oembed
+      - https://www.embases.com/e/*
+    url: https://www.embases.com/api/oembed
     discovery: true


### PR DESCRIPTION
Embases is a chart embedding SaaS. Users create charts from Notion, Airtable or Google Sheets and embed them via iFrame or direct link.

oEmbed endpoint: https://embases.com/api/oembed
Example URL: https://www.embases.com/e/f2410f45b431c26c8b62e505ab54df2a322f7f492d7b1378f433656ac9181600
