### PR TITLE
Add CircleZeroEight provider

### DIFF
--- a/providers/CircleZeroEight.yml
+++ b/providers/CircleZeroEight.yml
@@ -1,0 +1,16 @@
+---
+- provider_name: CircleZeroEight
+  provider_url: https://www.circlezeroeight.com
+  endpoints:
+  - schemes:
+    - https://www.circlezeroeight.com/features/*
+    - https://www.circlezeroeight.com/news/*
+    - https://www.circlezeroeight.com/sport/*
+    - https://www.circlezeroeight.com/style/*
+    - https://www.circlezeroeight.com/culture/*
+    url: https://www.circlezeroeight.com/api/oembed
+    example_urls:
+    - https://www.circlezeroeight.com/api/oembed?url=https%3A%2F%2Fwww.circlezeroeight.com%2Ffeatures%2Fjamal-musiala
+    discovery: true
+    notes: Provider only supports the 'link' type
+...


### PR DESCRIPTION
Adding CircleZeroEight — a premium sports, style, and culture magazine based in the UK — as an oEmbed provider.

- **Provider URL:** https://www.circlezeroeight.com
- **Endpoint:** https://www.circlezeroeight.com/api/oembed
- **Discovery:** Yes, via `<link rel="alternate" type="application/json+oembed">` on article pages
- **Supported schemes:** `/features/*`, `/news/*`, plus planned pillar routes `/sport/*`, `/style/*`, `/culture/*`
- **Response type:** `link` (title, author, thumbnail, provider metadata)
- **Example verified:** https://www.circlezeroeight.com/api/oembed?url=https%3A%2F%2Fwww.circlezeroeight.com%2Ffeatures%2Fjamal-musiala

Implemented April 2026 per oEmbed 1.0 spec. CORS open, cache-control max-age, validates host + article path before responding.