### PR TITLE
Add Laude provider configuration

### DIFF
--- a/providers/Laude.yml
+++ b/providers/Laude.yml
@@ -1,0 +1,17 @@
+---
+- provider_name: Laude
+  provider_url: https://laude.org
+  endpoints:
+  - schemes:
+    - https://laude.org/impact/*
+    - https://laude.org/im/*
+    url: http://laude.org/api/oembed
+    example_urls:
+    - http://laude.org/api/oembed?url=https%3A%2F%2Flaude.org%2Fimpact/andy-konwinski
+    - http://laude.org/api/oembed?url=https%3A%2F%2Flaude.org%2Fim/andy-konwinski
+    - http://laude.org/api/oembed?url=https%3A%2F%2Flaude.org%2Fimpact/david-patterson
+    - http://laude.org/api/oembed?url=https%3A%2F%2Flaude.org%2Fim/david-patterson
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Adding Laude — profiles for computer science researchers

- Provider URL: https://laude.org
- Endpoint: http://laude.org/api/oembed
- Discovery: All profile pages at laude.org/impact have `<link rel="alternate" type="application/json+oembed">`
- Supported schemes: /impact – individual profiles
- Example verified: http://laude.org/api/oembed?url=https%3A%2F%2Flaude.org%2Fimpact/andy-konwinski

<img width="1786" height="586" alt="Laude Laude Institute …" src="https://github.com/user-attachments/assets/c1047b73-f24b-4dc6-8a2d-e6afa329ba0b" />
