### PR TITLE
Add Kommodo (kommodo.ai) provider

### DIFF
--- a/providers/Kommodo.yml
+++ b/providers/Kommodo.yml
@@ -1,0 +1,18 @@
+---
+- provider_name: Kommodo
+  provider_url: https://kommodo.ai/
+  endpoints:
+  - schemes:
+    - https://kommodo.ai/recordings/*
+    - https://kommodo.ai/guides/*
+    url: https://kommodo.ai/api/oembed
+    discovery: true
+    formats:
+    - json
+    - xml
+    example_urls:
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Frecordings%2FabcDEF123
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Fguides%2FabcDEF123
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Frecordings%2FabcDEF123&format=json
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Fguides%2FabcDEF123&format=xml
+...


### PR DESCRIPTION
Adds Kommodo (https://kommodo.ai/) as a provider.

- **Provider**: Kommodo
- **Endpoint**: `https://kommodo.ai/api/oembed`
- **Schemes**: `https://kommodo.ai/recordings/*`, `https://kommodo.ai/guides/*`
- **Discovery**: yes (the canonical recording and guide pages emit `<link rel="alternate" type="application/json+oembed">` discovery tags)
- **Formats**: json, xml

Recordings return `type: video` (or `rich` when bundled with a step-by-step guide), guides return `type: rich` with an article-style HTML embed by default.

Test endpoint examples:

- https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Frecordings%2FabcDEF123
- https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Fguides%2FabcDEF123&format=json