### PR TITLE
Add Kommodo (kommodo.ai) provider

### DIFF
--- a/providers/Kommodo.yml
+++ b/providers/Kommodo.yml
@@ -1,0 +1,19 @@
+---
+- provider_name: Kommodo
+  provider_url: https://kommodo.ai/
+  endpoints:
+  - schemes:
+    - https://kommodo.ai/recordings/*
+    - https://kommodo.ai/guides/*
+    url: https://kommodo.ai/api/oembed
+    discovery: true
+    formats:
+    - json
+    - xml
+    example_urls:
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Frecordings%2FuzTHxzcd2IjpKkbPbmt2
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Fguides%2F7EL2huRx4PBjqLvsG4vF
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Frecordings%2FuzTHxzcd2IjpKkbPbmt2&format=json
+    - https://kommodo.ai/api/oembed?url=https%3A%2F%2Fkommodo.ai%2Fguides%2F7EL2huRx4PBjqLvsG4vF&format=xml
+    notes: Returns 'video' for recordings (or 'rich' when bundled with a step-by-step guide) and 'rich' for guides. Guides default to an article-style HTML embed; ?view=interactive in the source URL returns the slideshow variant.
+...


### PR DESCRIPTION
Adds Kommodo (https://kommodo.ai/) — a screen recording, AI summarization, and step-by-step guide platform — as an oEmbed provider.

## Provider details

- **Provider name:** Kommodo
- **Provider URL:** https://kommodo.ai/
- **oEmbed endpoint:** `https://kommodo.ai/api/oembed`
- **Discovery:** yes — the canonical recording and guide pages emit `<link rel="alternate" type="application/json+oembed">` discovery tags
- **Formats:** json, xml

## Schemes

- `https://kommodo.ai/recordings/*` — screen recording pages, return oEmbed `type: video` (or `rich` when bundled with a step-by-step guide)
- `https://kommodo.ai/guides/*` — step-by-step guide pages, return `type: rich` with an article-style HTML embed by default. Appending `?view=interactive` to the source URL returns the slideshow variant at 640x427.

## Verified example URLs

All four example URLs in `providers/Kommodo.yml` resolve against prod with valid oEmbed responses:

| URL | Status | Content-Type |
| --- | --- | --- |
| `…/api/oembed?url=…/recordings/uzTHxzcd2IjpKkbPbmt2` | 200 | application/json |
| `…/api/oembed?url=…/guides/7EL2huRx4PBjqLvsG4vF` | 200 | application/json |
| `…/api/oembed?url=…/recordings/uzTHxzcd2IjpKkbPbmt2&format=json` | 200 | application/json |
| `…/api/oembed?url=…/guides/7EL2huRx4PBjqLvsG4vF&format=xml` | 200 | text/xml |

The endpoint also returns `Access-Control-Allow-Origin: *` and `Cache-Control: public, s-maxage=3600, stale-while-revalidate=600` on success, and follows oEmbed § 2.3.5 status codes (404 for unknown URLs, 401 for password-protected, 501 for unsupported formats).