### PR TITLE
Add Risky Business as an oEmbed provider

### DIFF
--- a/providers/riskybiz.yml
+++ b/providers/riskybiz.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Risky Business
+  provider_url: https://risky.biz/
+  endpoints:
+    - schemes:
+        - https://risky.biz/*
+      url: https://risky.biz/oembed
+      discovery: true
+      formats:
+        - json
+      example_urls:
+        - https://risky.biz/oembed?url=https://risky.biz/RBNEWS560/&format=json


### PR DESCRIPTION
This adds Risky Business (https://risky.biz) as an oEmbed provider.

Risky Business publishes cybersecurity news podcasts (Risky Business,
Risky Bulletin, Between Two Nerds, Srsly Risky Biz, and Features). Each
episode page exposes an oEmbed endpoint via discovery, returning a
'rich' response with an embeddable audio player.

Schemes cover the URL prefix conventions used for episode pages:

  - https://risky.biz/*

Endpoint: https://risky.biz/oembed
Discovery: yes (link rel="alternate" type="application/json+oembed")
Formats: JSON