### PR TITLE
Add FazenHaus provider configuration

### DIFF
--- a/providers/fazenhaus.yml
+++ b/providers/fazenhaus.yml
@@ -1,0 +1,10 @@
+- provider_name: FazenHaus
+  provider_url: https://haus.fazen.co/
+  endpoints:
+  - schemes:
+    - https://haus.fazen.co/embed/music/*
+    url: https://haus.fazen.co/api/oembed
+    discovery: true
+    example_urls:
+    - https://haus.fazen.co/api/oembed?url=https%3A%2F%2Fhaus.fazen.co%2Fembed%2Fmusic%2F0cc8fd6654d0&format=json
+    


### PR DESCRIPTION
FazenHaus provides embeddable ambient music players for wedding websites.

- oEmbed endpoint: https://haus.fazen.co/api/oembed
- Returns type: rich (iframe, transparent background)
- Example: https://haus.fazen.co/embed/music/0cc8fd6654d0