### PR TITLE
Add World Cup 2026 Tour provider

### DIFF
--- a/providers/worldcup2026-tour.yml
+++ b/providers/worldcup2026-tour.yml
@@ -1,0 +1,16 @@
+---
+- provider_name: World Cup 2026 Tour
+  provider_url: https://ay-worldcup2026.zeabur.app
+  endpoints:
+  - schemes:
+    - https://ay-worldcup2026.zeabur.app/
+    - https://ay-worldcup2026.zeabur.app/widget
+    - https://ay-worldcup2026.zeabur.app/badge
+    - https://ay-worldcup2026.zeabur.app/developers
+    url: https://ay-worldcup2026.zeabur.app/oembed
+    example_urls:
+    - https://ay-worldcup2026.zeabur.app/oembed?url=https%3A%2F%2Fay-worldcup2026.zeabur.app%2Fwidget&format=json
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Adds World Cup 2026 Tour as an oEmbed provider.\n\nThe provider exposes a free World Cup 2026 schedule/widget surface with oEmbed discovery on the homepage and widget page. The endpoint returns JSON rich embeds for the next-match widget.\n\nValidation run:\n- npm install\n- npm run build\n- confirmed providers.json includes World Cup 2026 Tour\n- production endpoint check: https://ay-worldcup2026.zeabur.app/oembed?url=https%3A%2F%2Fay-worldcup2026.zeabur.app%2Fwidget&format=json