### PR TITLE
fix(json): add CORS header to providers endpoint

### DIFF
--- a/www/json.php
+++ b/www/json.php
@@ -1,5 +1,6 @@
 <?php
 	header('Content-type: application/json; charset=utf-8');
+	header('Access-Control-Allow-Origin: *');
 
 
 	#


### PR DESCRIPTION
Browsers block client-side fetches without Access-Control-Allow-Origin.

Closes iamcal/oembed#308