### PR TITLE
Add Ecency provider

### DIFF
--- a/providers/ecency.com.yml
+++ b/providers/ecency.com.yml
@@ -1,0 +1,11 @@
+---
+- provider_name: Ecency
+  provider_url: https://ecency.com/
+  endpoints:
+  - schemes:
+    - https://ecency.com/@*/*
+    - https://ecency.com/*/@*/*
+    url: https://ecency.com/api/oembed
+    discovery: true
+    example_urls:
+    - https://ecency.com/api/oembed?url=https%3A%2F%2Fecency.com%2F%40ecency%2Fsearch-on-ecency-just-got&format=json


### PR DESCRIPTION
Add **Ecency** (https://ecency.com) as an oEmbed provider.

Ecency is a web client for the [Hive](https://hive.io) blockchain. Posts now support oEmbed (JSON, type `link`) so that pasting a post URL produces a preview card.

- **Endpoint:** `https://ecency.com/api/oembed`
- **discovery:** `true` — a `<link rel="alternate" type="application/json+oembed">` is also present on every post page.
- Schemes cover the bare `/@author/permlink` and the category-prefixed `/category/@author/permlink` forms.

Example: `https://ecency.com/api/oembed?url=https%3A%2F%2Fecency.com%2F%40ecency%2Fsearch-on-ecency-just-got&format=json`
