### PR TITLE
chore: maintenance tooling — issue templates, stale bot, periodic audit sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Bug report to help us improve the project
+title: "[Bug]: "
+labels: ["Bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Provide a clear and concise description of what the bug is. Include screenshots if possible."
+      placeholder: "A clear and concise description of what the bug is."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: "Please provide the steps to reproduce the behavior."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: "A clear and concise description of what you expected to happen."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected-area
+    attributes:
+      label: Affected Area
+      description: "Which part of the project is affected by this bug?"
+      options:
+        - Website (oembed.com)
+        - Provider Registry (providers/*.yml)
+        - Audit Script (scripts/audit.js)
+        - GitHub Actions Workflow
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: "Add any other context about the problem here (e.g., browser, OS, logs)."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "oEmbed Spec Question"
+    url: "https://github.com/iamcal/oembed/discussions"
+    about: "Please ask and answer questions about the oEmbed spec here."
+  - name: "oEmbed Website"
+    url: "https://oembed.com"
+    about: "The oEmbed official website."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest an idea or enhancement for this project
+title: "[Feature]: "
+labels: ["Enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature! Please provide a clear and detailed explanation.
+
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: "A clear and concise description of what the problem is. Ex. This will help with the oEmbed project to..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution-description
+    attributes:
+      label: Describe the solution you'd like
+      description: "A clear and concise description of what you want to happen."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: "A clear and concise description of any alternative solutions or features you've considered."
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: "Add any other context or screenshots about the feature request here."

--- a/.github/ISSUE_TEMPLATE/provider-request.yml
+++ b/.github/ISSUE_TEMPLATE/provider-request.yml
@@ -1,0 +1,68 @@
+name: Add a New oEmbed Provider
+description: Request to add a new oEmbed provider to the registry
+title: "Add Provider: [Provider Name]"
+labels: ["Provider"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to the oEmbed provider registry! Please fill out the following fields as accurately as possible.
+
+  - type: input
+    id: provider-name
+    attributes:
+      label: Provider Name
+      description: "The official name of the service."
+      placeholder: "eg Example"
+    validations:
+      required: true
+
+  - type: input
+    id: provider-url
+    attributes:
+      label: Provider URL
+      description: "The main homepage for the service."
+      placeholder: "https://www.example.com/"
+    validations:
+      required: true
+
+  - type: textarea
+    id: schemes
+    attributes:
+      label: URL Schemes
+      description: "A list of URL schemes that the oEmbed endpoint should match. Use a wildcard (*) for variable parts. Please list one scheme per line."
+      placeholder: |
+        https://*.example.com/watch*
+        https://example.net/*
+    validations:
+      required: true
+
+  - type: input
+    id: endpoint-url
+    attributes:
+      label: oEmbed Endpoint URL
+      description: "The URL for the oEmbed API endpoint."
+      placeholder: "https://www.example.com/oembed"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: discovery
+    attributes:
+      label: Discovery Support
+      description: "Does the provider support oEmbed discovery via <link> tags in their HTML?"
+      options:
+        - "Yes"
+        - "No"
+        - "I don't know"
+    validations:
+      required: true
+
+  - type: textarea
+    id: example-urls
+    attributes:
+      label: Example URLs
+      description: "Please provide at least one full, working oEmbed API URL to a valid resource that we can use for testing."
+      placeholder: "https://www.example.com/oembed?url=https%3A%2F%2Fwww.example.com%2Fwatch%3Fv%3DiwGFalTRHDA"
+    validations:
+      required: true

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,51 @@
+name: Audit Providers
+
+on:
+  schedule:
+    # Weekly, Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+
+    - run: npm install --ignore-scripts
+
+    # Audits providers/ and providers-disabled/, moves confirmed-broken
+    # providers out and recovered ones back, and refreshes AUDIT.md.
+    - name: Audit and sync providers
+      run: npm run audit:sync
+
+    # Enabled set may have changed, so rebuild the published registry.
+    - name: Rebuild providers.json
+      run: npm run build
+
+    - name: Open pull request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        branch: chore/audit-sync
+        title: 'chore: sync provider registry from audit'
+        commit-message: 'chore: sync provider registry from audit'
+        body: |
+          Automated weekly audit run.
+
+          - Confirmed-broken providers moved to `providers-disabled/`.
+          - Recovered providers moved back to `providers/`.
+          - `AUDIT.md` and `providers.json` refreshed.
+
+          Review the moved files before merging — `INCONCLUSIVE` providers are left untouched.
+        labels: automation
+        delete-branch: true

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,31 @@
+name: Stale Issues Management
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Mark and close stale issues
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs within 7 days of this post.
+
+          stale-issue-label: 'stale'
+
+          days-before-stale: 7
+
+          days-before-close: 7
+
+          exempt-issue-labels: 'Postpone'

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node ./build.js providers/*.yml > providers.json",
+    "audit": "node ./scripts/audit.js",
+    "audit:sync": "node ./scripts/audit.js --sync > AUDIT.md",
     "prepare": "npm run build"
   },
   "repository": {

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -5,7 +5,9 @@ const reachableUrl = require('reachable-url')
 const { isReachable } = reachableUrl
 
 const CONCURRENCY = 10
-const PROVIDERS_DIR = path.join(__dirname, '..', 'providers')
+const ENABLED_DIR = process.env.OEMBED_ENABLED_DIR || path.join(__dirname, '..', 'providers')
+const DISABLED_DIR = process.env.OEMBED_DISABLED_DIR || path.join(__dirname, '..', 'providers-disabled')
+const PROVIDERS_DIR = ENABLED_DIR
 
 const OPTS = {
   timeout: { request: 15_000 },
@@ -82,8 +84,8 @@ async function checkEndpoint (endpoint) {
   return { url: endpoint.url, verdict: 'fail', endpointCheck, via: 'all_dead' }
 }
 
-async function auditProvider (file) {
-  const content = fs.readFileSync(path.join(PROVIDERS_DIR, file), 'utf8')
+async function auditProvider (file, baseDir = PROVIDERS_DIR) {
+  const content = fs.readFileSync(path.join(baseDir, file), 'utf8')
   const entries = yaml.load(content)
   const results = []
 
@@ -105,6 +107,7 @@ async function auditProvider (file) {
 
     results.push({
       file,
+      baseDir,
       name: entry.provider_name,
       providerUrl: entry.provider_url,
       endpoints: endpointResults,
@@ -198,7 +201,78 @@ function markdownTable (results) {
   return lines.join('\n')
 }
 
+function auditDir (baseDir) {
+  const files = fs.readdirSync(baseDir).filter(f => f.endsWith('.yml'))
+  return files.map(file => () => auditProvider(file, baseDir))
+}
+
+// A file may hold several provider entries; collapse them to one verdict.
+// FAIL wins (any broken endpoint), otherwise OK only when everything is OK,
+// otherwise INCONCLUSIVE.
+function fileVerdicts (results) {
+  const byFile = new Map()
+  for (const r of results) {
+    if (!byFile.has(r.file)) byFile.set(r.file, [])
+    byFile.get(r.file).push(r.verdict)
+  }
+  const out = new Map()
+  for (const [file, verdicts] of byFile) {
+    let verdict
+    if (verdicts.includes('FAIL')) verdict = 'FAIL'
+    else if (verdicts.every(v => v === 'OK')) verdict = 'OK'
+    else verdict = 'INCONCLUSIVE'
+    out.set(file, verdict)
+  }
+  return out
+}
+
+// Audit both directories and move files across the enabled/disabled line:
+// confirmed-broken providers get disabled, recovered ones get re-enabled.
+// INCONCLUSIVE never moves. Returns the list of moves performed.
+async function sync () {
+  console.error('Auditing enabled providers...\n')
+  const enabled = await runWithConcurrency(auditDir(ENABLED_DIR), CONCURRENCY)
+  console.error('\n\nAuditing disabled providers...\n')
+  const disabled = await runWithConcurrency(auditDir(DISABLED_DIR), CONCURRENCY)
+  console.error('\n')
+
+  const moves = []
+
+  for (const [file, verdict] of fileVerdicts(enabled)) {
+    if (verdict === 'FAIL') {
+      fs.renameSync(path.join(ENABLED_DIR, file), path.join(DISABLED_DIR, file))
+      moves.push({ file, action: 'disabled' })
+    }
+  }
+
+  for (const [file, verdict] of fileVerdicts(disabled)) {
+    if (verdict === 'OK') {
+      fs.renameSync(path.join(DISABLED_DIR, file), path.join(ENABLED_DIR, file))
+      moves.push({ file, action: 'enabled' })
+    }
+  }
+
+  // Report against the full set so AUDIT.md documents everything we checked.
+  console.log(markdownTable([...enabled, ...disabled]))
+
+  if (moves.length === 0) {
+    console.error('No provider moves required.')
+  } else {
+    console.error(`\nMoved ${moves.length} provider file(s):`)
+    for (const m of moves) console.error(`  ${m.action === 'disabled' ? '→ disabled' : '← enabled '} ${m.file}`)
+  }
+
+  return moves
+}
+
 async function main () {
+  const args = process.argv.slice(2)
+
+  if (args.includes('--sync')) {
+    await sync()
+    return
+  }
+
   const files = getFilesToAudit()
 
   if (files.length === 0) {


### PR DESCRIPTION
Maintenance tooling, partly salvaged from #835 (closed) plus the periodic audit automation.

## Issue templates (`.github/ISSUE_TEMPLATE/`)
- `bug-report.yml`, `feature-request.yml`
- `provider-request.yml` — structured new-provider form (name, URL, schemes, endpoint, discovery, example URLs)
- `config.yml` — disables blank issues, links Discussions + oembed.com
- Bug-report "Affected Area" matches current repo (providers registry, `scripts/audit.js`).

## Stale-issue bot (`.github/workflows/stale-issues.yml`)
- `actions/stale@v9`, daily; stale after 7d inactivity, closed 7d later; `Postpone` exempt.

## Periodic audit + auto enable/disable
- `scripts/audit.js --sync`: audits **both** `providers/` and `providers-disabled/`, then:
  - moves confirmed-broken (`FAIL`) enabled providers → `providers-disabled/`
  - moves recovered (`OK`) disabled providers → `providers/`
  - leaves `INCONCLUSIVE` untouched
  - writes the full report to `AUDIT.md`
- npm scripts: `audit` (check) and `audit:sync` (sync + AUDIT.md). Dirs overridable via `OEMBED_ENABLED_DIR` / `OEMBED_DISABLED_DIR` (testing).
- `.github/workflows/audit.yml`: weekly (Mon 06:00 UTC) + manual dispatch. Runs the sync, rebuilds `providers.json`, and opens a PR with the moves for review — no direct pushes to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)