### PR TITLE
Add TLexDR oEmbed provider

### DIFF
--- a/providers/TLexDR.yml
+++ b/providers/TLexDR.yml
@@ -1,0 +1,10 @@
+---
+- provider_name: TLexDR
+  provider_url: https://tlexdr.com/
+  endpoints:
+  - schemes:
+    - https://tlexdr.com/episode/*
+    url: https://tlexdr.com/oembed
+    discovery: true
+    example_urls:
+    - https://tlexdr.com/oembed?url=https%3A%2F%2Ftlexdr.com%2Fepisode%2F498


### PR DESCRIPTION
Adds [TLexDR](https://tlexdr.com) as an oEmbed provider.

TLexDR publishes 5-minute AI-generated briefs of every Lex Fridman Podcast episode. Each episode page exposes an embeddable episode-brief widget via a documented oEmbed 1.0 endpoint, with `<link rel="alternate" type="application/json+oembed">` discovery tags in the page `<head>`.

- **Endpoint:** `https://tlexdr.com/oembed` (returns `type: rich`, JSON)
- **Scheme:** `https://tlexdr.com/episode/*`
- **Discovery:** supported

Live example (returns a valid rich response):
`https://tlexdr.com/oembed?url=https%3A%2F%2Ftlexdr.com%2Fepisode%2F498&format=json`