### PR TITLE
TED: add http://www and embed.ted.com talk URL schemes

### DIFF
--- a/providers/ted.yml
+++ b/providers/ted.yml
@@ -5,7 +5,9 @@
   - schemes:
     - http://ted.com/talks/*
     - https://ted.com/talks/*
+    - http://www.ted.com/talks/*
     - https://www.ted.com/talks/*
+    - https://embed.ted.com/talks/*
     url: https://www.ted.com/services/v1/oembed.{format}
     example_urls:
     - https://www.ted.com/services/v1/oembed.xml?url=https%3A%2F%2Fwww.ted.com%2Ftalks%2Fjill_bolte_taylor_s_powerful_stroke_of_insight


### PR DESCRIPTION
The TED provider lists the correct endpoint, but two URL schemes the endpoint actually serves are missing from the registry. Both return valid oEmbed responses today (verified against `https://www.ted.com/services/v1/oembed.json?url=...`):

- `http://www.ted.com/talks/*` — the only `www.` + `http` combo that was absent
- `https://embed.ted.com/talks/*` — the canonical embed URL; WordPress already matches it via regex, the registry didn't

`providers/ted.yml` only. Endpoint and `example_urls` unchanged.
