### PR TITLE
Add TextExpander as an oEmbed provider

### DIFF
--- a/providers/textexpander.yml
+++ b/providers/textexpander.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: TextExpander
+  provider_url: https://textexpander.com
+  endpoints:
+  - schemes:
+    - https://rest-prod.tenet.textexpander.com/share/*
+    url: https://rest-prod.tenet.textexpander.com/oembed
+    example_urls:
+    - https://rest-prod.tenet.textexpander.com/oembed?format=json&url=https%3A%2F%2Frest-prod.tenet.textexpander.com%2Fshare%2FlhrNSr7UzQw
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Adds TextExpander as an oEmbed provider.

- Provider: `https://textexpander.com/`
- Endpoint: `https://rest-prod.tenet.textexpander.com/oembed `(JSON)
- Scheme: `https://rest-prod.tenet.textexpander.com/share/*` (shared snippet pages)
- Discovery: yes — share pages serve `<link rel="alternate" type="application/json+oembed">`
- Type: `rich`

Example call: `https://rest-prod.tenet.textexpander.com/oembed?format=json&url=https%3A%2F%2Frest-prod.tenet.textexpander.com%2Fshare%2FlhrNSr7UzQw`

**Note on endpoint access:** The oEmbed endpoint restricts access to certain user agents as a security measure. The audit script works correctly because it sends requests with a Slackbot user agent (Slackbot 1.0 (+https://api.slack.com/robots), [line 14](vscode-webview://0chmv4pal6pobocoa87lst260elusa5db5mt1gkmenb4toegilgv/scripts/audit.js#L14)), which is one of the allowed clients — consistent with how oEmbed consumers actually call the endpoint in production.