### PR TITLE
Add Fritube provider

### DIFF
--- a/providers/Fritube.yml
+++ b/providers/Fritube.yml
@@ -1,0 +1,12 @@
+- provider_name: Fritube
+  provider_url: https://fritube.ch
+  endpoints:
+  - schemes:
+    - https://fritube.ch/v/*
+    url: https://fritube.ch/services/oembed
+    example_urls:
+    - https://fritube.ch/services/oembed?url=https%3A%2F%2Ffritube.ch%2Fv%2F18dt2g&format=json
+    discovery: true
+    formats:
+    - json
+    - xml


### PR DESCRIPTION
## Add Fritube as an oEmbed provider

[Fritube](https://fritube.ch) is the media platform of **Centre fritic** (the ICT-in-education service of the Canton of Fribourg, Switzerland). It hosts educational **videos and audio** and plays them via a Video.js player at `https://fritube.ch/v/{id}`.

Fritube now exposes a spec-compliant **oEmbed** endpoint so its media can be embedded anywhere (Moodle, CMS, etc.) from the short URL alone.

### Endpoint
- **URL:** `https://fritube.ch/services/oembed`
- **Scheme:** `https://fritube.ch/v/*`
- **Formats:** JSON (default) + XML
- **Discovery:** yes — `<link rel="alternate" type="application/json+oembed">` is present in the `<head>` of every `/v/{id}` page
- **CORS:** `Access-Control-Allow-Origin: *`, responses cached 1h
- **Type:** `video` (also used for audio, with a compact player)

### Live example
```
curl -s 'https://fritube.ch/services/oembed?url=https%3A%2F%2Ffritube.ch%2Fv%2F18dt2g&format=json'
```
returns a valid oEmbed `video` payload (title, html iframe, width/height, thumbnail_url, …). The example URL points to a permanent public demo (Sintel, Blender Foundation).

`npm run build` passes with the new provider included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)