### PR TITLE
Add Orizn Widgets provider

### DIFF
--- a/providers/orizn.yml
+++ b/providers/orizn.yml
@@ -1,0 +1,16 @@
+---
+- provider_name: Orizn Widgets
+  provider_url: https://embed.orizn.app
+  endpoints:
+  - schemes:
+    - https://embed.orizn.app/frame/*
+    - https://embed.orizn.app/widgets/*
+    url: https://embed.orizn.app/api/oembed
+    discovery: true
+    formats:
+    - json
+    example_urls:
+    - https://embed.orizn.app/api/oembed?url=https%3A%2F%2Fembed.orizn.app%2Fwidgets%2Fvisa&format=json
+    - https://embed.orizn.app/api/oembed?url=https%3A%2F%2Fembed.orizn.app%2Fframe%2Fbudget%3Fdestination%3DVNM&format=json
+    notes: Provider only supports the 'rich' type (interactive travel widgets)
+...


### PR DESCRIPTION
Adds Orizn Widgets (https://embed.orizn.app) — free embeddable travel widgets (visa checker, budget calculator, passport score, country comparison, travel checklist) used on travel blogs and publisher sites.

- Endpoint: `https://embed.orizn.app/api/oembed` (JSON, rich type)
- Schemes: `https://embed.orizn.app/frame/*` and `https://embed.orizn.app/widgets/*`
- Discovery links are served on all consumable URLs
- Both `example_urls` return valid oEmbed 1.0 responses; unsupported `format` values return 501, non-provider URLs return 404 per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)