### PR TITLE
fix(audit): gate recovered providers on the schema validator

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,6 +22,13 @@ jobs:
       with:
         node-version: lts/*
 
+    # test.php gates recovered providers during the sync (see scripts/audit.js).
+    - name: Setup PHP with PECL extension
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.0'
+        extensions: yaml
+
     - run: npm install --ignore-scripts
 
     # Audits providers/ and providers-disabled/, moves confirmed-broken

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,18 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Run tests
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+
+    - run: npm install --ignore-scripts
+
+    - name: Run schema tests
       run: php test.php
+
+    - name: Run audit unit tests
+      run: npm test
 
   audit:
     if: github.event_name == 'pull_request'
@@ -41,7 +51,11 @@ jobs:
       id: changed
       run: |
         FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '^providers/' || true)
-        echo "files=$FILES" >> "$GITHUB_OUTPUT"
+        {
+          echo "files<<EOF"
+          echo "$FILES"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "providers.*"
   ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "build": "node ./build.js providers/*.yml > providers.json",
     "audit": "node ./scripts/audit.js",
     "audit:sync": "node ./scripts/audit.js --sync > AUDIT.md",

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const { spawnSync } = require('child_process')
 const yaml = require('js-yaml')
 const reachableUrl = require('reachable-url')
 const { isReachable } = reachableUrl
@@ -8,6 +9,7 @@ const CONCURRENCY = 10
 const ENABLED_DIR = process.env.OEMBED_ENABLED_DIR || path.join(__dirname, '..', 'providers')
 const DISABLED_DIR = process.env.OEMBED_DISABLED_DIR || path.join(__dirname, '..', 'providers-disabled')
 const PROVIDERS_DIR = ENABLED_DIR
+const TEST_PHP = process.env.OEMBED_TEST_PHP || path.join(__dirname, '..', 'test.php')
 
 const OPTS = {
   timeout: { request: 15_000 },
@@ -226,6 +228,45 @@ function fileVerdicts (results) {
   return out
 }
 
+// Reachability only proves the endpoint answers — the build gate (test.php)
+// still enforces the provider schema. A file can be reachable yet invalid (e.g.
+// a wildcard in the endpoint url), so re-enabling it on reachability alone would
+// break the build. Run the same gate over the enabled dir and revert any file
+// this sync just enabled that fails it. test.php exits non-zero on the first
+// offending file and names it, so loop until the gate passes. Returns the files
+// reverted back to disabled.
+function revertRecoveredFailures (enabledFiles) {
+  const reverted = []
+
+  while (enabledFiles.size > 0) {
+    const res = spawnSync('php', [TEST_PHP, ENABLED_DIR], { encoding: 'utf8' })
+
+    if (res.error) {
+      throw new Error(`Could not run schema gate (${TEST_PHP}): ${res.error.message}`)
+    }
+    if (res.status === 0) break
+
+    const out = `${res.stdout || ''}${res.stderr || ''}`
+    const match = out.match(/\/([^/\s]+\.yml)\b/)
+    if (!match) {
+      throw new Error(`Schema gate failed but named no provider file:\n${out}`)
+    }
+
+    const file = match[1]
+    if (!enabledFiles.has(file)) {
+      // A pre-existing enabled provider is failing the gate — not ours to
+      // revert. Surface it instead of silently touching another file.
+      throw new Error(`Schema gate failed on ${file}, which this sync did not enable:\n${out}`)
+    }
+
+    fs.renameSync(path.join(ENABLED_DIR, file), path.join(DISABLED_DIR, file))
+    enabledFiles.delete(file)
+    reverted.push(file)
+  }
+
+  return reverted
+}
+
 // Audit both directories and move files across the enabled/disabled line:
 // confirmed-broken providers get disabled, recovered ones get re-enabled.
 // INCONCLUSIVE never moves. Returns the list of moves performed.
@@ -252,17 +293,27 @@ async function sync () {
     }
   }
 
+  // Gate recoveries on the build's schema validator, reverting any that fail.
+  const enabledNow = new Set(moves.filter(m => m.action === 'enabled').map(m => m.file))
+  const reverted = new Set(revertRecoveredFailures(enabledNow))
+  const applied = moves.filter(m => !(m.action === 'enabled' && reverted.has(m.file)))
+
   // Report against the full set so AUDIT.md documents everything we checked.
   console.log(markdownTable([...enabled, ...disabled]))
 
-  if (moves.length === 0) {
-    console.error('No provider moves required.')
-  } else {
-    console.error(`\nMoved ${moves.length} provider file(s):`)
-    for (const m of moves) console.error(`  ${m.action === 'disabled' ? '→ disabled' : '← enabled '} ${m.file}`)
+  if (reverted.size > 0) {
+    console.error(`\nKept ${reverted.size} reachable provider(s) disabled — they fail the schema gate:`)
+    for (const file of reverted) console.error(`  ✗ rejected  ${file}`)
   }
 
-  return moves
+  if (applied.length === 0) {
+    console.error('\nNo provider moves required.')
+  } else {
+    console.error(`\nMoved ${applied.length} provider file(s):`)
+    for (const m of applied) console.error(`  ${m.action === 'disabled' ? '→ disabled' : '← enabled '} ${m.file}`)
+  }
+
+  return applied
 }
 
 async function main () {
@@ -296,7 +347,11 @@ async function main () {
   }
 }
 
-main().catch(err => {
-  console.error(err)
-  process.exit(1)
-})
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err)
+    process.exit(1)
+  })
+}
+
+module.exports = { revertRecoveredFailures, ENABLED_DIR, DISABLED_DIR, TEST_PHP }

--- a/scripts/audit.test.js
+++ b/scripts/audit.test.js
@@ -1,0 +1,100 @@
+'use strict'
+
+// Gate test for the audit sync's schema check. It exercises the real test.php
+// validator against throwaway provider dirs, so it stays deterministic, local,
+// and free (no network — the reachability audit is not touched here).
+
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const enabledDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oembed-enabled-'))
+const disabledDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oembed-disabled-'))
+
+// audit.js reads these at require time.
+process.env.OEMBED_ENABLED_DIR = enabledDir
+process.env.OEMBED_DISABLED_DIR = disabledDir
+
+const { revertRecoveredFailures } = require('./audit.js')
+
+// The gate shells out to `php test.php`; skip cleanly where php/yaml is absent
+// so a dev box without the extension does not report a false failure. CI (build
+// and audit workflows) sets up php+yaml, so the gate is always covered there.
+const phpReady = (() => {
+  const res = spawnSync('php', ['-r', 'exit(function_exists("yaml_parse_file") ? 0 : 1);'])
+  return !res.error && res.status === 0
+})()
+
+const VALID = [
+  '- provider_name: Good',
+  '  provider_url: https://good.example',
+  '  endpoints:',
+  '    - schemes:',
+  '        - https://good.example/*',
+  '      url: https://good.example/oembed'
+].join('\n') + '\n'
+
+// Reachable in the wild, but the endpoint url carries a wildcard — exactly the
+// slateapp case that broke the build in PR #901.
+const WILDCARD_URL = [
+  '- provider_name: Bad',
+  '  provider_url: https://bad.example',
+  '  endpoints:',
+  '    - schemes:',
+  '        - https://*.bad.example/work/*',
+  '      url: https://*.bad.example/oembed'
+].join('\n') + '\n'
+
+function reset () {
+  for (const dir of [enabledDir, disabledDir]) {
+    for (const f of fs.readdirSync(dir)) fs.rmSync(path.join(dir, f))
+  }
+}
+
+function writeEnabled (name, body) {
+  fs.writeFileSync(path.join(enabledDir, name), body)
+}
+
+test('reverts a recovered provider that fails the schema gate', { skip: !phpReady && 'php with yaml extension not available' }, () => {
+  reset()
+  writeEnabled('good.yml', VALID)
+  writeEnabled('bad.yml', WILDCARD_URL)
+
+  const reverted = revertRecoveredFailures(new Set(['good.yml', 'bad.yml']))
+
+  assert.deepStrictEqual(reverted, ['bad.yml'])
+  assert.ok(fs.existsSync(path.join(disabledDir, 'bad.yml')), 'invalid file moved back to disabled')
+  assert.ok(!fs.existsSync(path.join(enabledDir, 'bad.yml')), 'invalid file no longer enabled')
+  assert.ok(fs.existsSync(path.join(enabledDir, 'good.yml')), 'valid file stays enabled')
+})
+
+test('leaves valid recoveries untouched', { skip: !phpReady && 'php with yaml extension not available' }, () => {
+  reset()
+  writeEnabled('good.yml', VALID)
+
+  const reverted = revertRecoveredFailures(new Set(['good.yml']))
+
+  assert.deepStrictEqual(reverted, [])
+  assert.ok(fs.existsSync(path.join(enabledDir, 'good.yml')))
+})
+
+test('throws when the failing file is not one it enabled', { skip: !phpReady && 'php with yaml extension not available' }, () => {
+  reset()
+  writeEnabled('good.yml', VALID)
+  writeEnabled('preexisting.yml', WILDCARD_URL) // invalid, but not in the recovery set
+
+  assert.throws(
+    () => revertRecoveredFailures(new Set(['good.yml'])),
+    /did not enable/
+  )
+  // Must not touch a file outside its own recovery set.
+  assert.ok(fs.existsSync(path.join(enabledDir, 'preexisting.yml')))
+})
+
+test.after(() => {
+  fs.rmSync(enabledDir, { recursive: true, force: true })
+  fs.rmSync(disabledDir, { recursive: true, force: true })
+})

--- a/test.php
+++ b/test.php
@@ -1,4 +1,8 @@
 <?php
+	# Directory to validate. Defaults to "providers"; pass a path to validate
+	# another directory (used by the audit sync to gate recovered providers).
+	$dir = isset($argv[1]) ? rtrim($argv[1], '/') : 'providers';
+
 	$num_files = 0;
 	$num_entries = 0;
 
@@ -27,19 +31,19 @@
 #echo var_export($p2);
 #exit;
 
-	$dh = opendir('providers');
+	$dh = opendir($dir);
 	while (($file = readdir($dh)) !== false){
 		if (preg_match('!\.yml$!', $file)){
-			$partial = yaml_parse_file("providers/$file");
+			$partial = yaml_parse_file("$dir/$file");
 			if (!$partial || !is_array($partial)){
-				echo "Unable to parse provider file providers/$file\n";
+				echo "Unable to parse provider file $dir/$file\n";
 				exit(1);
 			}
 
 			# check if there is more than one document in the file
-			$full = yaml_parse_file("providers/$file", -1);
+			$full = yaml_parse_file("$dir/$file", -1);
 			if (count($full) != 1){
-				echo "More than one YAML document specified in providers/$file\n";
+				echo "More than one YAML document specified in $dir/$file\n";
 				echo "(The file should end with \"...\", not \"---\")\n";
 				exit(1);
 			}
@@ -55,7 +59,7 @@
 			$keys = check_keys($partial);
 			foreach ($keys as $k){
 				if (!isset($expected_keys[$k])){
-					echo "Unexpected key {$k} in provider file providers/$file\n";
+					echo "Unexpected key {$k} in provider file $dir/$file\n";
 					exit(1);
 				}
 			}
@@ -67,7 +71,7 @@
 
 			foreach ($partial as $def){
 				if (!isset($def['endpoints']) || !count($def['endpoints'])){
-					echo "No endpoints defined in provider file providers/$file\n";
+					echo "No endpoints defined in provider file $dir/$file\n";
 					exit(1);
 				}
 				foreach ($def['endpoints'] as $endpoint){
@@ -77,20 +81,20 @@
 
 					if (!isset($endpoint['discovery']) || $endpoint['discovery'] === 0){
 						if (!isset($endpoint['schemes']) || !count($endpoint['schemes'])){
-							echo "Endpoint without schemes or discovery found in provider file providers/$file\n";
+							echo "Endpoint without schemes or discovery found in provider file $dir/$file\n";
 							print_r($endpoint);
 							exit(1);
 						}
 					}
 
 					if (!isset($endpoint['url'])){
-						echo "Endpoint without URL found in provider file providers/$file\n";
+						echo "Endpoint without URL found in provider file $dir/$file\n";
 						print_r($endpoint);
 						exit(1);
 					}
 
 					if (preg_match('!\*!', $endpoint['url'])){
-						echo "Endpoint URL contains a wildcard in provider file providers/$file\n";
+						echo "Endpoint URL contains a wildcard in provider file $dir/$file\n";
 						print_r($endpoint);
 						exit(1);
 					}
@@ -99,13 +103,13 @@
 					foreach ($endpoint['example_urls'] as $example){
 
 						if (!preg_match('!^https?://!', $example)){
-							echo "Endpoint example URL does not start with http:// or https:// in provider file providers/$file\n";
+							echo "Endpoint example URL does not start with http:// or https:// in provider file $dir/$file\n";
 							print_r($endpoint);
 							exit(1);
 						}
 
 						if (!preg_match('!url=!', $example)){
-							echo "Endpoint example URL does not contain url= param in provider file providers/$file\n";
+							echo "Endpoint example URL does not contain url= param in provider file $dir/$file\n";
 							print_r($endpoint);
 							exit(1);
 						}
@@ -116,20 +120,20 @@
 
 						# check for people trying to put regexes in the schemes (e.g. "(foo|bar)")
 						if (strpos($scheme, '(') !== false){
-							echo "Scheme contains illegal character '(' in provider file providers/$file\n";
+							echo "Scheme contains illegal character '(' in provider file $dir/$file\n";
 							print_r($endpoint['schemes']);
 							exit(1);
 						}
 
 						if (strpos($scheme, ')') !== false){
-							echo "Scheme contains illegal character ')' in provider file providers/$file\n";
+							echo "Scheme contains illegal character ')' in provider file $dir/$file\n";
 							print_r($endpoint['schemes']);
 							exit(1);
 						}
 
 						# check for wildcards in schemes (and that a scheme exists)
 						if (!preg_match('!^([a-z]+):!', $scheme)){
-							echo "Scheme URL must contain a scheme which itself may not contain wildcards in provider file providers/$file\n";
+							echo "Scheme URL must contain a scheme which itself may not contain wildcards in provider file $dir/$file\n";
 							print_r($endpoint['schemes']);
 							exit(1);
 						}
@@ -141,14 +145,14 @@
 
 							# allow 'foo.com' but no 'com'
 							if (count($parts) < 2){
-								echo "Scheme domain must be fully qualified in provider file providers/$file\n";
+								echo "Scheme domain must be fully qualified in provider file $dir/$file\n";
 								print_r($endpoint['schemes']);
 								exit(1);
 							}
 
 							# '*.foo.com' is ok, but '*.com' is not
 							if ($parts[0] == '*' || $parts[1] == '*'){
-								echo "Scheme domain may not contain a wildcard as the TLD in provider file providers/$file\n";
+								echo "Scheme domain may not contain a wildcard as the TLD in provider file $dir/$file\n";
 								print_r($endpoint['schemes']);
 								exit(1);
 							}
@@ -157,7 +161,7 @@
 							# so '*.foo.bar.com' is ok, but '*foo.bar.com' is not
 							foreach ($parts as $part){
 								if (strpos($part, '*') !== false && $part !== '*'){
-									echo "Scheme domain wildcards must be for a whole atom TLD in provider file providers/$file\n";
+									echo "Scheme domain wildcards must be for a whole atom TLD in provider file $dir/$file\n";
 									print_r($endpoint['schemes']);
 									exit(1);
 								}
@@ -170,7 +174,7 @@
 		}else if (in_array($file,  ['README.md', '.', '..'])){
 			# these are expected to be here
 		}else{
-			echo "Unexpected file {$file} in providers directory - your file must end in .yml\n";
+			echo "Unexpected file {$file} in {$dir} directory - your file must end in .yml\n";
 			exit(1);
 		}
 	}


### PR DESCRIPTION
Fixes the two CI failures on the weekly audit-sync PR (#901).

## What was failing

**1. `audit` job — `Invalid format 'providers/experiencebuilder.yml'`**
`.github/workflows/build.yml` wrote a multiline value to `$GITHUB_OUTPUT` using the single-line `name=value` syntax. Any PR touching more than one provider file trips it. Switched to the heredoc form.

**2. `build` job — `Endpoint URL contains a wildcard in provider file providers/slateapp.yml`**
The audit re-enabled `slateapp.yml` on reachability alone. Its endpoint url is `https://*.slateapp.com/api/v2/oembed` — reachable via its example subdomains, but the schema gate (`test.php`) forbids wildcards in `url`. Reachability and schema validity are different gates; the sync only checked the first.

## Fix

- `scripts/audit.js` now runs the real `test.php` gate over recovered providers and reverts any that fail back to `providers-disabled/`, so reachability can't reintroduce a schema violation. Failing files outside the recovery set are surfaced, not silently touched.
- `test.php` takes an optional directory arg (default `providers`) so the sync can validate the enabled dir. Fully backward compatible.
- `.github/workflows/audit.yml` sets up PHP+yaml so the gate runs in the weekly job.
- `scripts/audit.test.js` covers the gate (revert-on-fail, leave-valid, throw-on-foreign-file), wired into `npm test` and the `build` job.

## Verification

- `php test.php` — 281 files, pass.
- `npm test` — 3/3 pass.
- End-to-end against the real `slateapp.yml`: reverted; a valid provider alongside it stays enabled.

Note: this prevents recurrence but doesn't retroactively fix #901's branch — that PR should be closed and left to the next (now-gated) weekly audit, or rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)