### PR TITLE
add LiveCodes provider

### DIFF
--- a/providers/LiveCodes.yml
+++ b/providers/LiveCodes.yml
@@ -1,0 +1,21 @@
+---
+- provider_name: LiveCodes
+  provider_url: https://livecodes.io/
+  endpoints:
+  - schemes:
+    - https://livecodes.io/
+    - https://livecodes.io/?*
+    - https://*.livecodes.io/
+    - https://*.livecodes.io/?*
+    url: https://livecodes.io/oembed
+    example_urls:
+    - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact
+    - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dvue&format=json
+    - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Druby&maxwidth=700&maxheight=300
+    - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Fx%3Did%2Fnvpsgtwr6em
+    - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Fjs%3Dconsole.log(%2527hello%2520LiveCodes!%2527)%26console%3Dopen
+    discovery: true
+    formats:
+    - json
+    notes: Provider only supports the 'rich' type
+...

--- a/providers/LiveCodes.yml
+++ b/providers/LiveCodes.yml
@@ -8,6 +8,7 @@
     - https://*.livecodes.io/
     - https://*.livecodes.io/?*
     url: https://livecodes.io/oembed
+    docs_url: https://livecodes.io/docs/features/embeds
     example_urls:
     - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact
     - https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dvue&format=json


### PR DESCRIPTION
## Add provider: LiveCodes

This PR adds [LiveCodes](https://livecodes.io) as a provider.

LiveCodes is an open-source client-side code playground supporting 90+ languages and frameworks. Projects can be shared via URL (templates, short share IDs, or full config encoded in query params) and embedded in web pages.
See [LiveCodes docs](https://livecodes.io/docs) for more details.

### Endpoint

- **oEmbed endpoint:** `https://livecodes.io/oembed`
- **Format:** JSON only
- **Type:** `rich`
- **Discovery:** supported
- **Parameters:** supports `url` (required), `maxwidth`, `maxheight`, and `format`

### Schemes

- `https://livecodes.io/`
- `https://livecodes.io/?*`
- `https://*.livecodes.io/`
- `https://*.livecodes.io/?*`

### Example requests

All example URLs are live and return valid oEmbed JSON:

- https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact
- https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dvue&format=json
- https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Druby&maxwidth=700&maxheight=300
- https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Fx%3Did%2Fnvpsgtwr6em
- https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Fjs%3Dconsole.log(%2527hello%2520LiveCodes!%2527)%26console%3Dopen

### Example response

`GET https://livecodes.io/oembed?url=https%3A%2F%2Flivecodes.io%2F%3Ftemplate%3Dreact`

```json
{
  "type": "rich",
  "version": "1.0",
  "provider_name": "LiveCodes",
  "provider_url": "https://livecodes.io",
  "title": "React Starter - LiveCodes",
  "width": 800,
  "height": 400,
  "thumbnail_url": "https://livecodes.io/livecodes/assets/images/livecodes-text-logo.png",
  "thumbnail_width": 1200,
  "thumbnail_height": 630,
  "cache_age": "3600",
  "html": "\u003Ciframe\n        src=\"https://livecodes.io/?template=react\"\n        title=\"React Starter - LiveCodes\"\n        loading=\"lazy\"\n        scrolling=\"no\"\n        allowfullscreen\n        height=\"400\"\n        style=\"border: 1px solid black; border-radius: 6px; width: 100%;\"\n      \u003E\u003C/iframe\u003E"
}
```

Requests for URLs that do not match the schemes return 404 Not Found; unsupported formats (e.g. format=xml) return 501 Not Implemented, per the spec.

Docs: https://livecodes.io/docs/features/embeds