### PR TITLE
ci(audit): only open a sync PR when a provider actually moves

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -40,7 +40,22 @@ jobs:
     - name: Rebuild providers.json
       run: npm run build
 
+    # A run that moves nothing still rewrites AUDIT.md to the runner's vantage
+    # (a datacenter IP can't see past Cloudflare, so counts wobble). That diff is
+    # noise, so only open a PR when a provider .yml actually crossed the
+    # enabled/disabled line — a rename shows up as a delete + an untracked add.
+    - name: Detect provider moves
+      id: moves
+      run: |
+        if [ -n "$(git status --porcelain -- providers providers-disabled | grep -E '\.yml$')" ]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No provider moves — skipping PR."
+        fi
+
     - name: Open pull request
+      if: steps.moves.outputs.changed == 'true'
       uses: peter-evans/create-pull-request@v7
       with:
         branch: chore/audit-sync


### PR DESCRIPTION
The weekly **Audit Providers** sync always rewrites `AUDIT.md`, so a run that moves no providers still opens a PR — like #908, whose only diff was `AUDIT.md` churned to the CI runner's vantage. From a GitHub datacenter IP a few Cloudflare-gated providers (CodePen, Kickstarter…) read as unverified, so the verified/unverified counts wobble even when nothing actually changed. That's noise.

This gates the `create-pull-request` step on whether a provider `.yml` actually crossed the enabled/disabled line. A `git rename` surfaces as a delete + an untracked add across `providers/` and `providers-disabled/`; if neither is present, the run logs "No provider moves — skipping PR" and exits without opening one.

Real moves (a recovered or newly-dead provider) still open a PR as before, carrying the `AUDIT.md` + `providers.json` refresh with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)