### PR TITLE
Add Carbon Voice provider

### DIFF
--- a/providers/CarbonVoice.yml
+++ b/providers/CarbonVoice.yml
@@ -1,0 +1,12 @@
+---
+- provider_name: Carbon Voice
+  provider_url: https://carbonvoice.app/
+  endpoints:
+  - schemes:
+    - https://carbonvoice.app/s/*
+    - https://carbonvoice.app/m/*
+    - https://carbonvoice.app/c/*
+    url: https://carbonvoice.app/api/oembed
+    discovery: true
+    example_urls:
+    - https://carbonvoice.app/api/oembed?url=https%3A%2F%2Fcarbonvoice.app%2Fs%2F9DZPZUKtFnaBhlkR


### PR DESCRIPTION
Adds [Carbon Voice](https://carbonvoice.app) — voice messaging with transcripts. Embeds are interactive audio/video players (Player.js supported), served from a dedicated embed service.

- Endpoint: `https://carbonvoice.app/api/oembed` (json, discovery tags present on content pages)
- Schemes: share links (`/s/*`), messages (`/m/*`), channels (`/c/*`)
- Live example: https://carbonvoice.app/api/oembed?url=https%3A%2F%2Fcarbonvoice.app%2Fs%2F9DZPZUKtFnaBhlkR