### PR TITLE
Add VidLink provider

### DIFF
--- a/providers/VidLink.yml
+++ b/providers/VidLink.yml
@@ -1,0 +1,12 @@
+- provider_name: VidLink
+  provider_url: https://vidlink.it
+  endpoints:
+  - schemes:
+    - https://vidlink.it/videos/*
+    - https://www.vidlink.it/videos/*
+    url: https://www.vidlink.it/api/oembed
+    example_urls:
+    - https://www.vidlink.it/api/oembed?url=https%3A%2F%2Fvidlink.it%2Fvideos%2Fwidows-bay&format=json
+    discovery: true
+    formats:
+    - json


### PR DESCRIPTION
Adds VidLink (https://vidlink.it) — interactive videos with clickable overlay links.

- Endpoint: https://www.vidlink.it/api/oembed (JSON)
- Discovery tags present on all /videos/* pages
- Live example: https://www.vidlink.it/api/oembed?url=https%3A%2F%2Fvidlink.it%2Fvideos%2Fwidows-bay&format=json
- Returns type=video with responsive iframe html, respects maxwidth, 404 on unknown URLs, 501 on format=xml