### PR TITLE
Add Pyzia provider

### DIFF
--- a/providers/pyzia.yml
+++ b/providers/pyzia.yml
@@ -1,0 +1,17 @@
+---
+- provider_name: Pyzia
+  provider_url: https://www.pyzia.app/
+  endpoints:
+  - schemes:
+    - https://www.pyzia.app/dashboard?*
+    - https://pyzia.app/dashboard?*
+    - https://www.pyzia.app/embed/chart?*
+    - https://pyzia.app/embed/chart?*
+    url: https://www.pyzia.app/api/oembed
+    example_urls:
+    - https://www.pyzia.app/api/oembed?url=https%3A%2F%2Fwww.pyzia.app%2Fdashboard%3Find%3DMAC_ECON_GDP_PCAP%26entities%3Dunited-states%2Cchina%26start%3D2000%26end%3D2024
+    discovery: true
+    formats:
+    - json
+    notes: Provider only supports the 'rich' type
+...


### PR DESCRIPTION
[Pyzia](https://www.pyzia.app/) is an interactive charting tool for public economic and company data — users build charts comparing countries, regions, and companies across decades of indicators, and each chart has a stable URL.

- Endpoint: https://www.pyzia.app/api/oembed (JSON, `rich` type only)
- Discovery `<link>` tags are present on chart pages
- Working example: [oEmbed response](https://www.pyzia.app/api/oembed?url=https%3A%2F%2Fwww.pyzia.app%2Fdashboard%3Find%3DMAC_ECON_GDP_PCAP%26entities%3Dunited-states%2Cchina%26start%3D2000%26end%3D2024) for [this chart](https://www.pyzia.app/dashboard?ind=MAC_ECON_GDP_PCAP&entities=united-states,china&start=2000&end=2024)