### PR TITLE
Add Clipform provider

### DIFF
--- a/providers/clipform.yml
+++ b/providers/clipform.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Clipform
+  provider_url: https://clipform.io/
+  endpoints:
+  - schemes:
+    - https://clipform.io/*
+    url: https://api.clipform.io/v1/oembed
+    discovery: true
+    formats:
+    - json
+    example_urls:
+    - https://api.clipform.io/v1/oembed?url=https%3A%2F%2Fclipform.io%2Fc4479d620
+    - https://api.clipform.io/v1/oembed?url=https%3A%2F%2Fclipform.io%2Fc4479d620&format=json


### PR DESCRIPTION
Adds Clipform (https://clipform.io) - a video-driven form builder where each form URL is an interactive video form respondents fill in-place.

- Endpoint: https://api.clipform.io/v1/oembed (JSON, type: rich, supports maxwidth/maxheight, CORS-enabled)
- Discovery link tags are live on all published form pages
- Live example: https://api.clipform.io/v1/oembed?url=https%3A%2F%2Fclipform.io%2Fc4479d620
- Schemes use the root wildcard because share URLs are root-level ids (clipform.io/<id>); the endpoint 404s any non-form URL
- `npm test` passes with the new entry