### PR TITLE
Add Coloring Monster provider

### DIFF
--- a/providers/coloringmonster.yml
+++ b/providers/coloringmonster.yml
@@ -1,0 +1,15 @@
+---
+- provider_name: Coloring Monster
+  provider_url: https://coloringmonster.com
+  endpoints:
+  - schemes:
+    - https://coloringmonster.com/coloring-page/*
+    - https://coloringmonster.com/monsterpieces/*
+    url: https://coloringmonster.com/oembed
+    discovery: true
+    formats:
+    - json
+    - xml
+    example_urls:
+    - https://coloringmonster.com/oembed?url=https%3A%2F%2Fcoloringmonster.com%2Fcoloring-page%2Fa-dragon-in-a-meadow-5dfc159b&format=json
+...


### PR DESCRIPTION
Adds Coloring Monster (https://coloringmonster.com) - a coloring page platform where every public coloring page and user-colored "Monsterpiece" is embeddable as an interactive widget.

- Endpoint: https://coloringmonster.com/oembed (JSON + XML, type: rich, supports maxwidth/maxheight)
- Discovery link tags are live on all embeddable pages
- Live example: https://coloringmonster.com/oembed?url=https%3A%2F%2Fcoloringmonster.com%2Fcoloring-page%2Fa-dragon-in-a-meadow-5dfc159b&format=json
- Schemes cover our two primary content types (`/coloring-page/*`, `/monsterpieces/*`). We have taxonomy pages that are discovery only.
- `npm test` passes with the new entry