### PR TITLE
Add FrameRate provider

### DIFF
--- a/providers/framerate.yml
+++ b/providers/framerate.yml
@@ -10,4 +10,4 @@
         - json
         - xml
       example_urls:
-        - https://framerate.tv/api/oembed?url=https://framerate.tv/watch/ecafd426-c293-4ebb-8b45-efb2086d6479
+        - https://framerate.tv/api/oembed?url=https://framerate.tv/watch/52e6a94a-6985-4611-ab4a-b1e7e047ef22

--- a/providers/framerate.yml
+++ b/providers/framerate.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: FrameRate
+  provider_url: https://framerate.tv/
+  endpoints:
+    - schemes:
+        - https://framerate.tv/watch/*
+      url: https://framerate.tv/api/oembed
+      discovery: true
+      formats:
+        - json
+        - xml
+      example_urls:
+        - https://framerate.tv/api/oembed?url=https://framerate.tv/watch/ecafd426-c293-4ebb-8b45-efb2086d6479


### PR DESCRIPTION
FrameRate (framerate.tv) is a video platform for filmmakers and motion designers. oEmbed endpoint supports JSON and XML with discovery tags live on video pages. Example URL returns a valid response.