### PR TITLE
Add Typecel provider

### DIFF
--- a/providers/Typecel.yml
+++ b/providers/Typecel.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Typecel
+  provider_url: https://app.typecel.io
+  endpoints:
+  - schemes:
+    - https://app.typecel.io/*/*
+    - https://app.typecel.io/embed/*/*
+    url: https://app.typecel.io/api/oembed
+    example_urls:
+    - https://app.typecel.io/api/oembed?url=https://app.typecel.io/shrivaas/(MSFT)%20Microsoft%20Corporation
+    discovery: false
+    notes: Provider only supports the 'rich' type
+...


### PR DESCRIPTION
Typecel (https://app.typecel.io) is a financial modelling platform; public and link-shared models embed as a live read-only editor.

- Endpoint: `https://app.typecel.io/api/oembed` (JSON; `format=xml` answers 501 per spec)
- Type: `rich` only
- Schemes: the canonical `/{handle}/{name}` model addresses and their `/embed/...` form
- The example URL is live and returns a working payload; the iframe it carries renders without login.