### PR TITLE
Add Tegula

### DIFF
--- a/providers/tegula.yml
+++ b/providers/tegula.yml
@@ -1,0 +1,17 @@
+---
+- provider_name: Tegula
+  provider_url: https://tegula.io
+  endpoints:
+  - schemes:
+    - https://tegula.io/m/*
+    - https://www.tegula.io/m/*
+    - https://tegula.io/cat.html?model=*
+    - https://www.tegula.io/cat.html?model=*
+    url: https://tegula.io/api/oembed/
+    discovery: true
+    example_urls:
+    - https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fm%2F11
+    - https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fcat.html%3Fmodel%3D11
+    formats:
+    - json
+...


### PR DESCRIPTION
Adds Tegula, a web viewer for massive textured 3D models used in cultural
heritage documentation (photogrammetry and lidar surveys of buildings,
sculptures and archaeological sites).

- **Endpoint:** `https://tegula.io/api/oembed/`
- **Format:** JSON, `type: rich`
- **Discovery:** yes. Each model has a canonical page at `https://tegula.io/m/<id>`
  carrying a `<link rel="alternate" type="application/json+oembed">` tag.
- `maxwidth` / `maxheight` are honoured, aspect ratio preserved.
- Non-public models return **404**, as the spec has no notion of a refusal.

Both hostnames are declared: `www.tegula.io` 301-redirects to the apex, but a
visitor may still paste either form.

All four declared schemes were verified against production before submitting.
`node build.js providers/*.yml` runs clean with the entry included.
