### PR TITLE
Add Slidesfly provider

### DIFF
--- a/providers/slidesfly.yml
+++ b/providers/slidesfly.yml
@@ -1,0 +1,15 @@
+---
+- provider_name: Slidesfly
+  provider_url: https://slidesfly.com
+  endpoints:
+  - schemes:
+    - https://slidesfly.xyz/d/*
+    url: https://slidesfly.com/api/oembed
+    docs_url: https://slidesfly.com/docs/embed
+    example_urls:
+    - https://slidesfly.com/api/oembed?url=https%3A%2F%2Fslidesfly.xyz%2Fd%2FnlTgWEixO2Ik0wYT9KsLDg&format=json
+    discovery: true
+    formats:
+    - json
+    notes: Provider supports public decks and the rich response type
+...


### PR DESCRIPTION
I maintain Slidesfly, a service for publishing and sharing AI-generated HTML presentations.

This adds its public deck reader as an oEmbed provider:

- Endpoint: `https://slidesfly.com/api/oembed`
- Scheme: `https://slidesfly.xyz/d/*`
- Format/type: JSON, `rich`
- Discovery: enabled on public reader pages
- Sizing: `maxwidth` and `maxheight` are honored proportionally
- Access: non-public decks return 401; unavailable decks return 404
- Unsupported XML requests return 501

The example is the public Reveal.js 6.0.1 deck used in Slidesfly's documentation.

Validation against current upstream (`e3a34db2383238c3e819b578814f4755a3e5cd56`):

- `npm test`: 19 passed, 0 failed; 3 PHP YAML checks skipped locally because the extension is unavailable
- `npm run build`: passed
- `npm run audit -- slidesfly.yml`: Verified 1, Unverified 0, Failed 0
