### PR TITLE
Adding  u-poll.com as provider

### DIFF
--- a/providers/u-poll.yml
+++ b/providers/u-poll.yml
@@ -4,6 +4,8 @@
   - schemes:
     - https://u-poll.com/p/*
     url: https://u-poll.com/oembed
-    discovery: true
+    docs_url: https://u-poll.com/faq
     example_urls:
     - https://u-poll.com/oembed?url=https://u-poll.com/p/nvidia-enters-windows-laptop-market-taking-on-intel-and-amd-who-will-lead-7uunsx&format=json
+    discovery: true
+    notes: Provider only supports the 'rich' type

--- a/providers/u-poll.yml
+++ b/providers/u-poll.yml
@@ -1,0 +1,9 @@
+- provider_name: u-poll
+  provider_url: https://u-poll.com
+  endpoints:
+  - schemes:
+    - https://u-poll.com/p/*
+    url: https://u-poll.com/oembed
+    discovery: true
+    example_urls:
+    - https://u-poll.com/oembed?url=https://u-poll.com/p/nvidia-enters-windows-laptop-market-taking-on-intel-and-amd-who-will-lead-7uunsx&format=json


### PR DESCRIPTION
Adds u-poll (https://u-poll.com), a polling/voting site, as an oEmbed provider.

Endpoint: https://u-poll.com/oembed
Spec-compliant, supports discovery (<link rel="alternate" type="application/json+oembed"> on poll pages).
Verified working example: https://u-poll.com/oembed?url=https://u-poll.com/p/nvidia-enters-windows-laptop-market-taking-on-intel-and-amd-who-will-lead-7uunsx&format=json