### PR TITLE
Add Castle provider

### DIFF
--- a/providers/castle.yml
+++ b/providers/castle.yml
@@ -1,0 +1,13 @@
+---
+- provider_name: Castle
+  provider_url: https://castle.xyz
+  endpoints:
+  - schemes:
+    - https://castle.xyz/d/*
+    url: https://castle.xyz/api/oembed
+    example_urls:
+    - https://castle.xyz/api/oembed?url=https://castle.xyz/d/004Sk5AZz7wY&format=json
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Adds [Castle](https://castle.xyz), a platform for making and playing games. Deck (game) pages at `https://castle.xyz/d/*` are instantly playable in the browser, and the oEmbed endpoint returns a `rich` payload with a playable iframe.

- Endpoint: `https://castle.xyz/api/oembed`
- Example: https://castle.xyz/api/oembed?url=https://castle.xyz/d/004Sk5AZz7wY&format=json
- Discovery `<link>` tags are live on all deck pages.

(Replaces #933, which was opened from the wrong fork.)