### PR TITLE
Add Mirame360 oEmbed provider

### DIFF
--- a/providers/Mirame360.yml
+++ b/providers/Mirame360.yml
@@ -10,7 +10,7 @@
     - https://mirame360.com/user/*/media/*
     url: https://mirame360.com/api/oembed/
     example_urls:
-    - https://mirame360.com/api/oembed/?url=https%3A%2F%2Fmirame360.com%2Ftour%2Ftest-tour%2F&format=json
+    - https://mirame360.com/api/oembed/?url=https%3A%2F%2Fmirame360.com%2Fvideo%2Furl%2Ftorres-de-serranos%2F&format=json
     discovery: true
     formats:
     - json

--- a/providers/Mirame360.yml
+++ b/providers/Mirame360.yml
@@ -1,0 +1,17 @@
+---
+- provider_name: Mirame360
+  provider_url: https://mirame360.com
+  endpoints:
+  - schemes:
+    - https://mirame360.com/embed/*
+    - https://mirame360.com/embed/tour/*
+    - https://mirame360.com/video/url/*
+    - https://mirame360.com/tour/*
+    - https://mirame360.com/user/*/media/*
+    url: https://mirame360.com/api/oembed/
+    example_urls:
+    - https://mirame360.com/api/oembed/?url=https%3A%2F%2Fmirame360.com%2Ftour%2Ftest-tour%2F&format=json
+    discovery: true
+    formats:
+    - json
+...


### PR DESCRIPTION
Adds Mirame360 (https://mirame360.com) as an oEmbed provider.

Mirame360 is a 360° photo/video hosting and virtual-tour platform. The
oEmbed endpoint is public, unauthenticated, and returns `type: video`
responses (an iframe embed) for public/embeddable 360 media and tours.

Endpoint: https://mirame360.com/api/oembed/
Supported URL schemes:
- https://mirame360.com/embed/*
- https://mirame360.com/embed/tour/*
- https://mirame360.com/video/url/*
- https://mirame360.com/tour/*
- https://mirame360.com/user/*/media/*

Verified working example (real production response, checked before
opening this PR):
https://mirame360.com/api/oembed/?url=https%3A%2F%2Fmirame360.com%2Fvideo%2Furl%2Ftorres-de-serranos%2F&format=json