### PR TITLE
ci: stop the stale bot from closing relevant issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -24,8 +24,10 @@ jobs:
 
           stale-issue-label: 'stale'
 
-          days-before-stale: 7
+          days-before-stale: 60
 
           days-before-close: 7
 
-          exempt-issue-labels: 'Postpone'
+          exempt-issue-labels: 'Postpone, next-version'
+
+          exempt-pr-labels: 'Postpone, next-version'


### PR DESCRIPTION
Prompted by #21, which has been marked stale three times and rescued three times by a contributor replying "This issue is still relevant."

Three problems in `.github/workflows/stale-issues.yml`:

1. `days-before-stale: 7` — a week of quiet is normal for a spec/provider registry. Bumped to 60.
2. `exempt-issue-labels: 'Postpone'` referenced a label that did not exist in this repo, so the exemption was dead config. I created the `Postpone` label and applied it to #21.
3. No `exempt-pr-labels`, so provider-submission PRs waiting on maintainer review were staled by the same rules.

Also added `next-version` to both exemption lists — an issue tagged for the next version is planned work, not abandoned work. Drop that part if you'd rather keep the label purely informational.

`days-before-close: 7` is unchanged and still matches the wording of `stale-issue-message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrPGBtLDkdnYXQv4u3r7bG