### PR TITLE
Add Tegula collection URL schemes

### DIFF
--- a/providers/tegula.yml
+++ b/providers/tegula.yml
@@ -5,12 +5,15 @@
   - schemes:
     - https://tegula.io/m/*
     - https://www.tegula.io/m/*
+    - https://tegula.io/c/*
+    - https://www.tegula.io/c/*
     - https://tegula.io/cat.html?model=*
     - https://www.tegula.io/cat.html?model=*
     url: https://tegula.io/api/oembed/
     discovery: true
     example_urls:
     - https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fm%2F11
+    - https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fc%2F1
     - https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fcat.html%3Fmodel%3D11
     formats:
     - json


### PR DESCRIPTION
Follow-up to #930, which added Tegula. This adds two URL schemes for a new
kind of embeddable resource: **collections** of 3D models.

A collection is a curated, ordered set of models. Its embed shows the
thumbnails and opens the chosen model in the same frame, so a single iframe
lets a visitor browse several models without leaving the host page.

## What changed

Three lines in `providers/tegula.yml`: the two `/c/*` schemes, with and
without `www`, and one example URL. The endpoint, the `discovery` flag and
the format are unchanged.

```diff
     - https://www.tegula.io/m/*
+    - https://tegula.io/c/*
+    - https://www.tegula.io/c/*
     - https://tegula.io/cat.html?model=*
```

## Checks

- `node build.js providers/*.yml` runs clean: 368 providers generated, the
  Tegula entry present with its six schemes.
- All six schemes queried against production through the endpoint, all
  `200`.
- The three `example_urls` return `200` with a valid oEmbed payload
  (`version`, `type: rich`, `provider_name`, `title`, `html`, `width`,
  `height`, `thumbnail_url` and its two dimensions).
- Discovery works without the registry too: `/c/<id>` serves the
  `application/json+oembed` link tag, as `/m/<id>` already does.

Example response for a collection:

    https://tegula.io/api/oembed/?format=json&url=https%3A%2F%2Ftegula.io%2Fc%2F1

## Note on privacy

A collection may gather models that are not public. The endpoint only ever
exposes the public ones, and the announced count is that of the visible
models, never the total.
