### PR TITLE
Add Keystone Practice provider

### DIFF
--- a/providers/keystone-practice.yml
+++ b/providers/keystone-practice.yml
@@ -1,0 +1,10 @@
+- provider_name: Keystone Practice
+  provider_url: https://keystonepractice.co
+  endpoints:
+  - schemes:
+    - https://keystonepractice.co/tools/*
+    - https://keystonepractice.co/embed/*
+    url: https://keystonepractice.co/api/oembed
+    discovery: true
+    example_urls:
+    - https://keystonepractice.co/api/oembed?url=https://keystonepractice.co/tools/clinician-net&format=json


### PR DESCRIPTION
Adds Keystone Practice (https://keystonepractice.co) — free financial calculators and reports for private mental-health practice owners.

- schemes are deliberately narrow: /tools/* (the pages people paste) and /embed/* (the chrome-less variant). No other path is claimed; shared-report links are excluded by design and the endpoint refuses them.
- discovery: true — every tool page carries the link rel=alternate application/json+oembed tag.
- The example URL resolves and returns a rich payload.
- JSON only; format=xml returns 501 as the spec suggests for unimplemented formats.