### PR TITLE
Add EveryPage provider

### DIFF
--- a/providers/everypage.yml
+++ b/providers/everypage.yml
@@ -1,0 +1,11 @@
+- provider_name: EveryPage
+  provider_url: https://everypage.co
+  endpoints:
+  - schemes:
+    - https://everypage.co/*
+    url: https://everypage.co/oembed
+    docs_url: https://everypage.co/developers
+    example_urls:
+    - https://everypage.co/oembed?url=https://everypage.co/dtbWJZUeUlv5
+    discovery: true
+    notes: Provider only supports the 'rich' type and format=json


### PR DESCRIPTION
Adds [EveryPage](https://everypage.co) — trackable document sharing (PDF flipbooks, share links, readership analytics).

- Endpoint: `https://everypage.co/oembed` (JSON, `rich` type)
- Discovery: `<link rel="alternate" type="application/json+oembed">` is served on share pages
- Live example: https://everypage.co/oembed?url=https://everypage.co/dtbWJZUeUlv5
- Docs: https://everypage.co/developers