### PR TITLE
Add Provider: Scibly

### DIFF
--- a/providers/scibly.yml
+++ b/providers/scibly.yml
@@ -1,0 +1,21 @@
+---
+- provider_name: Scibly
+  provider_url: https://www.scibly.com/
+  endpoints:
+  - schemes:
+    - https://app.scibly.com/public/courses/*
+    - https://app.scibly.com/embed/courses/*
+    - https://app.scibly.com/en/public/courses/*
+    - https://app.scibly.com/en/embed/courses/*
+    - https://app.scibly.com/de/public/courses/*
+    - https://app.scibly.com/de/embed/courses/*
+    url: https://app.scibly.com/api/oembed
+    discovery: true
+    formats:
+    - json
+    example_urls:
+    - https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fpublic%2Fcourses%2Fcms498ant000104jodpv63tys
+    - https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fembed%2Fcourses%2Fcms498ant000104jodpv63tys
+    - https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fen%2Fpublic%2Fcourses%2Fcms498ant000104jodpv63tys&maxwidth=480&maxheight=400
+    notes: Provider only supports the 'rich' type
+...


### PR DESCRIPTION
Adds Scibly to the provider registry.

**Provider Name:** Scibly

**Provider URL:** https://www.scibly.com/

**oEmbed Endpoint URL:** https://app.scibly.com/api/oembed

**Discovery Support:** Yes — public course pages emit
`<link rel="alternate" type="application/json+oembed" href="...">`.

**URL Schemes**

```
https://app.scibly.com/public/courses/*
https://app.scibly.com/embed/courses/*
https://app.scibly.com/en/public/courses/*
https://app.scibly.com/en/embed/courses/*
https://app.scibly.com/de/public/courses/*
https://app.scibly.com/de/embed/courses/*
```

Both the share link (`/public/courses/`) and the embed URL (`/embed/courses/`)
resolve to the same course, each with or without an `en`/`de` locale prefix.

**Example URLs**

- https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fpublic%2Fcourses%2Fcms498ant000104jodpv63tys
- https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fembed%2Fcourses%2Fcms498ant000104jodpv63tys
- https://app.scibly.com/api/oembed?url=https%3A%2F%2Fapp.scibly.com%2Fen%2Fpublic%2Fcourses%2Fcms498ant000104jodpv63tys&maxwidth=480&maxheight=400

Sample response:

```json
{
  "version": "1.0",
  "type": "rich",
  "provider_name": "scibly",
  "provider_url": "https://www.scibly.com",
  "title": "EU AI Transparency Obligations from 2 Aug 2026",
  "author_name": "Scibly Academy",
  "width": 640,
  "height": 600,
  "html": "<iframe src=\"https://app.scibly.com/embed/courses/cms498ant000104jodpv63tys\" ...></iframe>"
}
```

**Notes**

- JSON only. `format=xml` returns `501` rather than pretending to support it,
  which is why the entry declares `formats: [json]`.
- Only the `rich` type is returned. No `thumbnail_url`: the spec requires pixel
  dimensions alongside it and course thumbnails are stored without them.
- `maxwidth` / `maxheight` are honoured; height is only ever reduced from the
  default, never raised.
- The endpoint is CORS-open (`Access-Control-Allow-Origin: *`) and answers
  `OPTIONS`, since many consumers resolve links from the browser.
- Missing `url` → `400`, unknown or non-public course → `404`, off-origin
  `url` → `404`.

Ran `node scripts/audit.js providers/scibly.yml` locally: **Verified 1,
Unverified 0, Failed 0**. `npm test` passes (19/19, 3 skipped).
