### PR TITLE
Add Wikitólica as an oEmbed provider

### DIFF
--- a/providers/wikitolica.yml
+++ b/providers/wikitolica.yml
@@ -1,0 +1,18 @@
+---
+- provider_name: Wikitólica
+  provider_url: https://www.wikitolica.com
+  endpoints:
+  - schemes:
+    - https://www.wikitolica.com/*/*/
+    url: https://www.wikitolica.com/oembed
+    example_urls:
+    - https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fa%2Famor%2F&format=json
+    - https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fa%2Famor%2F&format=xml
+    - https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fj%2Fjesucristo%2F&format=json
+    - https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fj%2Fjesucristo%2F&format=xml
+    discovery: true
+    formats:
+    - json
+    - xml
+    notes: Provider only supports the 'link' type
+...


### PR DESCRIPTION
Add [Wikitólica](https://www.wikitolica.com/) as an oEmbed provider
 - Endpoint: [https://www.wikitolica.com/oembed](https://www.wikitolica.com/oembed) (JSON + XML, type: link)
 - Test url: [https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fa%2Famor%2F&format=json](https://www.wikitolica.com/oembed?url=https%3A%2F%2Fwww.wikitolica.com%2Fa%2Famor%2F&format=json)

Discovery tags are live on all covered pages.